### PR TITLE
Add options for configuring http/grpc

### DIFF
--- a/pkg/server/grpcconfig.go
+++ b/pkg/server/grpcconfig.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+type GRPCConfig struct {
+	port int
+	host string
+}
+type GRPCOption func(config *GRPCConfig)
+
+func NewGRPCConfig(options ...func(config *GRPCConfig)) *GRPCConfig {
+	config := &GRPCConfig{
+		port: 8081,
+		host: "localhost",
+	}
+	for _, opt := range options {
+		opt(config)
+	}
+
+	return config
+}
+
+func WithGRPCPort(port int) GRPCOption {
+	return func(config *GRPCConfig) {
+		config.port = port
+	}
+}
+
+func WithGRPCHost(host string) GRPCOption {
+	return func(config *GRPCConfig) {
+		config.host = host
+	}
+}

--- a/pkg/server/grpcconfig_test.go
+++ b/pkg/server/grpcconfig_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+)
+
+func TestNewGRPCConfig(t *testing.T) {
+	// Test default configuration
+	config := NewGRPCConfig()
+	if config.host != "localhost" {
+		t.Errorf("Expected host to be localhost, got %s", config.host)
+	}
+	if config.port != 8081 {
+		t.Errorf("Expected port to be 8081, got %d", config.port)
+	}
+}
+
+func TestWithGRPCPort(t *testing.T) {
+	config := NewGRPCConfig(WithGRPCPort(9000))
+	if config.port != 9000 {
+		t.Errorf("Expected port to be 9000, got %d", config.port)
+	}
+}
+
+func TestWithGRPCHost(t *testing.T) {
+	config := NewGRPCConfig(WithGRPCHost("example.com"))
+	if config.host != "example.com" {
+		t.Errorf("Expected host to be example.com, got %s", config.host)
+	}
+}
+
+func TestMultipleGRPCOptions(t *testing.T) {
+	config := NewGRPCConfig(
+		WithGRPCPort(9090),
+		WithGRPCHost("test.example.com"),
+	)
+	if config.port != 9090 {
+		t.Errorf("Expected port to be 9090, got %d", config.port)
+	}
+	if config.host != "test.example.com" {
+		t.Errorf("Expected host to be test.example.com, got %s", config.host)
+	}
+}

--- a/pkg/server/httpconfig.go
+++ b/pkg/server/httpconfig.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import "time"
+
+type HTTPConfig struct {
+	host        string
+	idleTimeout time.Duration
+	port        int
+}
+type HTTPOption func(config *HTTPConfig)
+
+func NewHTTPConfig(options ...func(config *HTTPConfig)) *HTTPConfig {
+	config := &HTTPConfig{
+		host:        "localhost",
+		idleTimeout: 60 * time.Second,
+		port:        8080,
+	}
+	for _, opt := range options {
+		opt(config)
+	}
+
+	return config
+}
+
+func WithHTTPPort(port int) HTTPOption {
+	return func(config *HTTPConfig) {
+		config.port = port
+	}
+}
+
+func WithHTTPHost(host string) HTTPOption {
+	return func(config *HTTPConfig) {
+		config.host = host
+	}
+}
+
+func WithHTTPIdleTimeout(idleTimeout time.Duration) HTTPOption {
+	return func(config *HTTPConfig) {
+		config.idleTimeout = idleTimeout
+	}
+}

--- a/pkg/server/httpconfig_test.go
+++ b/pkg/server/httpconfig_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewHTTPConfig(t *testing.T) {
+	// Test default configuration
+	config := NewHTTPConfig()
+	if config.host != "localhost" {
+		t.Errorf("Expected host to be localhost, got %s", config.host)
+	}
+	if config.idleTimeout != 60*time.Second {
+		t.Errorf("Expected idleTimeout to be 60s, got %v", config.idleTimeout)
+	}
+	if config.port != 8080 {
+		t.Errorf("Expected port to be 8080, got %d", config.port)
+	}
+}
+
+func TestWithHTTPPort(t *testing.T) {
+	config := NewHTTPConfig(WithHTTPPort(9000))
+	if config.port != 9000 {
+		t.Errorf("Expected port to be 9000, got %d", config.port)
+	}
+}
+
+func TestWithHTTPHost(t *testing.T) {
+	config := NewHTTPConfig(WithHTTPHost("example.com"))
+	if config.host != "example.com" {
+		t.Errorf("Expected host to be example.com, got %s", config.host)
+	}
+}
+
+func TestWithHTTPIdleTimeout(t *testing.T) {
+	config := NewHTTPConfig(WithHTTPIdleTimeout(30 * time.Second))
+	if config.idleTimeout != 30*time.Second {
+		t.Errorf("Expected idleTimeout to be 30s, got %v", config.idleTimeout)
+	}
+}
+
+func TestMultipleOptions(t *testing.T) {
+	config := NewHTTPConfig(
+		WithHTTPPort(9090),
+		WithHTTPHost("test.example.com"),
+		WithHTTPIdleTimeout(10*time.Second),
+	)
+	if config.port != 9090 {
+		t.Errorf("Expected port to be 9090, got %d", config.port)
+	}
+	if config.host != "test.example.com" {
+		t.Errorf("Expected host to be test.example.com, got %s", config.host)
+	}
+	if config.idleTimeout != 10*time.Second {
+		t.Errorf("Expected idleTimeout to be 10s, got %v", config.idleTimeout)
+	}
+}


### PR DESCRIPTION
part of #82 

#### Summary
Configuration objects for setting up the http/grpc servers. Anything in `cmd` should populate these and send them over so stuff in `pkg` doesn't need to look into cmd line parameters.

#### Release Note
NONE

#### Documentation
NONE