### PR TITLE
Add grpc and http servers.

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -16,16 +16,19 @@
 package app
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/version"
+
+	"github.com/sigstore/rekor-tiles/pkg/server"
 )
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "start the Rekor HTTP server",
-	Long:  "start the Rekor HTTP server",
+	Short: "start the Rekor server",
+	Long:  "start the Rekor server",
 	Run: func(_ *cobra.Command, _ []string) {
 		versionInfo := version.GetVersionInfo()
 		versionInfoStr, err := versionInfo.JSONString()
@@ -33,6 +36,15 @@ var serveCmd = &cobra.Command{
 			versionInfoStr = versionInfo.String()
 		}
 		slog.Info("starting rekor-server", "version", versionInfoStr)
+
+		// TODO: read values from cmdline
+		server.Serve(
+			context.Background(),
+			// TODO: use defaults for now, but really use commandline
+			server.NewHTTPConfig(),
+			server.NewGRPCConfig(),
+			&server.Server{},
+		)
 	},
 }
 

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"google.golang.org/grpc"
+)
+
+type grpcServer struct {
+	*grpc.Server
+	serverEndpoint string
+}
+
+func newGRPCService(config *GRPCConfig, server pb.RekorServer) *grpcServer {
+	// Create a gRPC Server object
+	s := grpc.NewServer()
+	pb.RegisterRekorServer(s, server)
+
+	return &grpcServer{s, fmt.Sprintf("%s:%v", config.host, config.port)}
+}
+
+func (gs *grpcServer) start(wg *sync.WaitGroup) {
+
+	slog.Info("starting grpc Server", "address", gs.serverEndpoint)
+
+	lis, err := net.Listen("tcp", gs.serverEndpoint)
+	if err != nil {
+		slog.Error("Failed to create listener:", "errors", err)
+		os.Exit(1)
+	}
+
+	// update the endpoint to standardize
+	gs.serverEndpoint = lis.Addr().String()
+
+	waitToClose := make(chan struct{})
+	go func() {
+		// capture interrupts and shutdown Server
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, syscall.SIGINT, syscall.SIGTERM)
+		<-sigint
+
+		gs.GracefulStop()
+		close(waitToClose)
+		slog.Info("stopped grpc Server")
+	}()
+
+	wg.Add(1)
+	go func() {
+		if err := gs.Serve(lis); err != nil {
+			slog.Error("error shutting down grpc Server", "errors", err)
+			os.Exit(1)
+		}
+		<-waitToClose
+		wg.Done()
+		slog.Info("grpc Server shutdown")
+	}()
+}

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,0 +1,97 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type httpProxy struct {
+	*http.Server
+	serverEndpoint string
+}
+
+func newHTTPProxy(ctx context.Context, config *HTTPConfig, grpcServer *grpcServer) *httpProxy {
+	mux := runtime.NewServeMux()
+
+	// TODO: allow TLS if the startup provides a TLS cert, but for now the proxy connects to grpc without TLS
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+
+	err := pb.RegisterRekorHandlerFromEndpoint(ctx, mux, grpcServer.serverEndpoint, opts)
+	if err != nil {
+		slog.Error("Failed to register gateway:", "errors", err)
+		os.Exit(1)
+	}
+
+	// TODO: configure https connection preferences (time-out, max size, etc)
+
+	endpoint := fmt.Sprintf("%s:%v", config.host, config.port)
+	return &httpProxy{
+		Server: &http.Server{
+			Addr:    endpoint,
+			Handler: mux,
+
+			ReadTimeout:       60 * time.Second,
+			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       config.idleTimeout,
+		},
+		serverEndpoint: endpoint,
+	}
+}
+
+func (hp *httpProxy) start(wg *sync.WaitGroup) {
+
+	slog.Info("starting http proxy", "address", hp.serverEndpoint)
+
+	waitToClose := make(chan struct{})
+	go func() {
+		// capture interrupts and shutdown Server
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, syscall.SIGINT, syscall.SIGTERM)
+		<-sigint
+
+		if err := hp.Shutdown(context.Background()); err != nil {
+			slog.Info("http Server Shutdown error", "errors", err)
+		}
+		close(waitToClose)
+		slog.Info("stopped http Server")
+	}()
+
+	wg.Add(1)
+	go func() {
+		if err := hp.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("could not start http listener", "errors", err)
+			os.Exit(1)
+		}
+		<-waitToClose
+		wg.Done()
+		slog.Info("http Server shutdown")
+	}()
+}

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+)
+
+func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s protobuf.RekorServer) {
+	var wg sync.WaitGroup
+
+	if hc.port == gc.port && hc.host == gc.host {
+		slog.Error("http and grpc cannot serve at the same address", "host", hc.host, "port", hc.port)
+		os.Exit(1)
+	}
+
+	grpcServer := newGRPCService(gc, s)
+	grpcServer.start(&wg)
+
+	httpProxy := newHTTPProxy(ctx, hc, grpcServer)
+	httpProxy.start(&wg)
+
+	wg.Wait()
+}

--- a/pkg/server/serve_test.go
+++ b/pkg/server/serve_test.go
@@ -40,7 +40,7 @@ func TestServe_smoke(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
 	gc := NewGRPCConfig()
 	hc := NewHTTPConfig()
-	s := &testServer{}
+	s := &mockServer{}
 
 	// Start the server
 	var wg sync.WaitGroup

--- a/pkg/server/serve_test.go
+++ b/pkg/server/serve_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestServe_smoke(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	gc := NewGRPCConfig()
+	hc := NewHTTPConfig()
+	s := &testServer{}
+
+	// Start the server
+	var wg sync.WaitGroup
+	go func() {
+		Serve(context.Background(), hc, gc, s)
+		wg.Done()
+	}()
+	wg.Add(1)
+
+	// check if we can hit grpc endpoints
+	conn, err := grpc.NewClient(
+		gc.host+":"+strconv.Itoa(gc.port),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := pb.NewRekorClient(conn)
+	defer conn.Close()
+	checkGRPCCreateEntry(t, client)
+	body, err := client.GetCheckpoint(context.Background(), &emptypb.Empty{})
+	checkGRPC(t, body, err, "test-checkpoint")
+	body, err = client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: 2})
+	checkGRPC(t, body, err, "test-tile:1,2")
+	body, err = client.GetPartialTile(context.Background(), &pb.PartialTileRequest{L: 1, N: "2.p", W: 3})
+	checkGRPC(t, body, err, "test-tile:1,2.p,3")
+	body, err = client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: 1})
+	checkGRPC(t, body, err, "test-entries:1")
+	body, err = client.GetPartialEntryBundle(context.Background(), &pb.PartialEntryBundleRequest{N: "1.p", W: 2})
+	checkGRPC(t, body, err, "test-entries:1.p,2")
+
+	// Check if we can hit HTTP endpoints
+	httpBaseURL := fmt.Sprintf("http://%s:%d", hc.host, hc.port)
+	checkHTTPPost(t, httpBaseURL)
+	checkHTTPGet(t, httpBaseURL+"/api/v2/checkpoint", "test-checkpoint")
+	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2", "test-tile:1,2")
+	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2.p/3", "test-tile:1,2.p,3")
+	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1", "test-entries:1")
+	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1.p/2", "test-entries:1.p,2")
+
+	// Simulate SIGTERM to trigger graceful shutdown
+	if err = syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("Could not kill server")
+	}
+
+	wg.Wait()
+}
+
+func checkGRPCCreateEntry(t *testing.T, client pb.RekorClient) {
+	if entry, err := client.CreateEntry(context.Background(), &pb.CreateEntryRequest{}); err != nil {
+		t.Fatal(err)
+	} else if !proto.Equal(entry, &testEntry) {
+		t.Errorf("Got entry %q, want %q", entry, &testEntry)
+	}
+}
+
+func checkGRPC(t *testing.T, resp *httpbody.HttpBody, err error, expectedBody string) {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resp.Data) != expectedBody {
+		t.Errorf("Got body %q, want %q", resp.Data, expectedBody)
+	}
+}
+
+func checkHTTPPost(t *testing.T, httpBaseURL string) {
+	resp, err := http.Post(httpBaseURL+"/api/v2/log/entries", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	entryJSON, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry pbs.TransparencyLogEntry
+	if err = protojson.Unmarshal(entryJSON, &entry); err != nil {
+		t.Fatal(err)
+	}
+	if !proto.Equal(&entry, &testEntry) {
+		t.Errorf("\ngot  :%+v\nwant :%+v", &entry, &testEntry)
+	}
+}
+
+func checkHTTPGet(t *testing.T, url, expectedBody string) {
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf(url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("%s: got %d want %d", url, resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != expectedBody {
+		t.Errorf("%s\ngot  :%q\nwant :%q", url, body, expectedBody)
+	}
+}

--- a/pkg/server/service_mock.go
+++ b/pkg/server/service_mock.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type testServer struct {
+type mockServer struct {
 	pb.UnimplementedRekorServer
 }
 
@@ -52,11 +52,11 @@ var testEntry = pbs.TransparencyLogEntry{
 	CanonicalizedBody: []byte("abcd"),
 }
 
-func (s *testServer) CreateEntry(_ context.Context, _ *pb.CreateEntryRequest) (*pbs.TransparencyLogEntry, error) {
+func (s *mockServer) CreateEntry(_ context.Context, _ *pb.CreateEntryRequest) (*pbs.TransparencyLogEntry, error) {
 	return &testEntry, nil
 }
 
-func (s *testServer) GetTile(_ context.Context, in *pb.TileRequest) (*httpbody.HttpBody, error) {
+func (s *mockServer) GetTile(_ context.Context, in *pb.TileRequest) (*httpbody.HttpBody, error) {
 	return &httpbody.HttpBody{
 		ContentType: "application/octet-stream",
 		Data:        []byte(fmt.Sprintf("test-tile:%d,%d", in.L, in.N)),
@@ -64,7 +64,7 @@ func (s *testServer) GetTile(_ context.Context, in *pb.TileRequest) (*httpbody.H
 	}, nil
 }
 
-func (s *testServer) GetPartialTile(_ context.Context, in *pb.PartialTileRequest) (*httpbody.HttpBody, error) {
+func (s *mockServer) GetPartialTile(_ context.Context, in *pb.PartialTileRequest) (*httpbody.HttpBody, error) {
 	return &httpbody.HttpBody{
 		ContentType: "application/octet-stream",
 		Data:        []byte(fmt.Sprintf("test-tile:%d,%s,%d", in.L, in.N, in.W)),
@@ -72,21 +72,21 @@ func (s *testServer) GetPartialTile(_ context.Context, in *pb.PartialTileRequest
 	}, nil
 }
 
-func (s *testServer) GetEntryBundle(_ context.Context, in *pb.EntryBundleRequest) (*httpbody.HttpBody, error) {
+func (s *mockServer) GetEntryBundle(_ context.Context, in *pb.EntryBundleRequest) (*httpbody.HttpBody, error) {
 	return &httpbody.HttpBody{
 		ContentType: "application/octet-stream",
 		Data:        []byte(fmt.Sprintf("test-entries:%d", in.N)),
 		Extensions:  nil,
 	}, nil
 }
-func (s *testServer) GetPartialEntryBundle(_ context.Context, in *pb.PartialEntryBundleRequest) (*httpbody.HttpBody, error) {
+func (s *mockServer) GetPartialEntryBundle(_ context.Context, in *pb.PartialEntryBundleRequest) (*httpbody.HttpBody, error) {
 	return &httpbody.HttpBody{
 		ContentType: "application/octet-stream",
 		Data:        []byte(fmt.Sprintf("test-entries:%s,%d", in.N, in.W)),
 		Extensions:  nil,
 	}, nil
 }
-func (s *testServer) GetCheckpoint(_ context.Context, _ *emptypb.Empty) (*httpbody.HttpBody, error) {
+func (s *mockServer) GetCheckpoint(_ context.Context, _ *emptypb.Empty) (*httpbody.HttpBody, error) {
 	return &httpbody.HttpBody{
 		ContentType: "application/octet-stream",
 		Data:        []byte("test-checkpoint"),

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	pbsc "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type testServer struct {
+	pb.UnimplementedRekorServer
+}
+
+var testEntry = pbs.TransparencyLogEntry{
+	LogIndex: 0,
+	LogId: &pbsc.LogId{
+		KeyId: []byte("abc"),
+	},
+	KindVersion: &pbs.KindVersion{
+		Kind:    "placeholder",
+		Version: "1.2.3",
+	},
+	IntegratedTime:   0,
+	InclusionPromise: nil,
+	InclusionProof: &pbs.InclusionProof{
+		LogIndex: 0,
+		RootHash: []byte("abc"),
+		TreeSize: 0,
+		Hashes:   [][]byte{[]byte("def"), []byte("ghi")},
+		Checkpoint: &pbs.Checkpoint{
+			Envelope: "placeholder",
+		},
+	},
+	CanonicalizedBody: []byte("abcd"),
+}
+
+func (s *testServer) CreateEntry(_ context.Context, _ *pb.CreateEntryRequest) (*pbs.TransparencyLogEntry, error) {
+	return &testEntry, nil
+}
+
+func (s *testServer) GetTile(_ context.Context, in *pb.TileRequest) (*httpbody.HttpBody, error) {
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        []byte(fmt.Sprintf("test-tile:%d,%d", in.L, in.N)),
+		Extensions:  nil,
+	}, nil
+}
+
+func (s *testServer) GetPartialTile(_ context.Context, in *pb.PartialTileRequest) (*httpbody.HttpBody, error) {
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        []byte(fmt.Sprintf("test-tile:%d,%s,%d", in.L, in.N, in.W)),
+		Extensions:  nil,
+	}, nil
+}
+
+func (s *testServer) GetEntryBundle(_ context.Context, in *pb.EntryBundleRequest) (*httpbody.HttpBody, error) {
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        []byte(fmt.Sprintf("test-entries:%d", in.N)),
+		Extensions:  nil,
+	}, nil
+}
+func (s *testServer) GetPartialEntryBundle(_ context.Context, in *pb.PartialEntryBundleRequest) (*httpbody.HttpBody, error) {
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        []byte(fmt.Sprintf("test-entries:%s,%d", in.N, in.W)),
+		Extensions:  nil,
+	}, nil
+}
+func (s *testServer) GetCheckpoint(_ context.Context, _ *emptypb.Empty) (*httpbody.HttpBody, error) {
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        []byte("test-checkpoint"),
+		Extensions:  nil,
+	}, nil
+}


### PR DESCRIPTION
Starts up servers and makes them available on localhost

todos:
- Add optional tls protection when communicating between http proxy and grpc service (see fulcio impl)
- Forward command line options to config objects (we use defaults)

#### Summary
Final part of #82

#### Release Note
NONE

#### Documentation
NONE