### PR TITLE
Make bad http requests fail

### DIFF
--- a/pkg/server/grpc_test.go
+++ b/pkg/server/grpc_test.go
@@ -16,49 +16,34 @@ package server
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"log/slog"
-	"net/http"
-	"os"
-	"strconv"
-	"sync"
-	"syscall"
 	"testing"
 
-	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func TestServe_smoke(t *testing.T) {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
-	gc := NewGRPCConfig()
-	hc := NewHTTPConfig()
-	s := &mockServer{}
-
-	// Start the server
-	var wg sync.WaitGroup
-	go func() {
-		Serve(context.Background(), hc, gc, s)
-		wg.Done()
-	}()
-	wg.Add(1)
+func TestServe_grpcSmoke(t *testing.T) {
+	// To debug set slog to output to stdout
+	// slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	server := MockServer{}
+	server.Start(t)
 
 	// check if we can hit grpc endpoints
 	conn, err := grpc.NewClient(
-		gc.host+":"+strconv.Itoa(gc.port),
+		server.gc.GRPCTarget(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	client := pb.NewRekorClient(conn)
 	defer conn.Close()
+
+	defer server.Stop(t)
+
 	checkGRPCCreateEntry(t, client)
 	body, err := client.GetCheckpoint(context.Background(), &emptypb.Empty{})
 	checkGRPC(t, body, err, "test-checkpoint")
@@ -70,22 +55,6 @@ func TestServe_smoke(t *testing.T) {
 	checkGRPC(t, body, err, "test-entries:1")
 	body, err = client.GetPartialEntryBundle(context.Background(), &pb.PartialEntryBundleRequest{N: "1.p", W: 2})
 	checkGRPC(t, body, err, "test-entries:1.p,2")
-
-	// Check if we can hit HTTP endpoints
-	httpBaseURL := fmt.Sprintf("http://%s:%d", hc.host, hc.port)
-	checkHTTPPost(t, httpBaseURL)
-	checkHTTPGet(t, httpBaseURL+"/api/v2/checkpoint", "test-checkpoint")
-	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2", "test-tile:1,2")
-	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2.p/3", "test-tile:1,2.p,3")
-	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1", "test-entries:1")
-	checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1.p/2", "test-entries:1.p,2")
-
-	// Simulate SIGTERM to trigger graceful shutdown
-	if err = syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
-		t.Fatalf("Could not kill server")
-	}
-
-	wg.Wait()
 }
 
 func checkGRPCCreateEntry(t *testing.T, client pb.RekorClient) {
@@ -102,48 +71,5 @@ func checkGRPC(t *testing.T, resp *httpbody.HttpBody, err error, expectedBody st
 	}
 	if string(resp.Data) != expectedBody {
 		t.Errorf("Got body %q, want %q", resp.Data, expectedBody)
-	}
-}
-
-func checkHTTPPost(t *testing.T, httpBaseURL string) {
-	resp, err := http.Post(httpBaseURL+"/api/v2/log/entries", "application/json", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
-	}
-	entryJSON, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var entry pbs.TransparencyLogEntry
-	if err = protojson.Unmarshal(entryJSON, &entry); err != nil {
-		t.Fatal(err)
-	}
-	if !proto.Equal(&entry, &testEntry) {
-		t.Errorf("\ngot  :%+v\nwant :%+v", &entry, &testEntry)
-	}
-}
-
-func checkHTTPGet(t *testing.T, url, expectedBody string) {
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatalf(url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("%s: got %d want %d", url, resp.StatusCode, http.StatusOK)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(body) != expectedBody {
-		t.Errorf("%s\ngot  :%q\nwant :%q", url, body, expectedBody)
 	}
 }

--- a/pkg/server/grpcconfig.go
+++ b/pkg/server/grpcconfig.go
@@ -14,6 +14,8 @@
 
 package server
 
+import "strconv"
+
 type GRPCConfig struct {
 	port int
 	host string
@@ -42,4 +44,8 @@ func WithGRPCHost(host string) GRPCOption {
 	return func(config *GRPCConfig) {
 		config.host = host
 	}
+}
+
+func (gc GRPCConfig) GRPCTarget() string {
+	return gc.host + ":" + strconv.Itoa(gc.port)
 }

--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestServe_httpSmoke(t *testing.T) {
+	// To debug set slog to output to stdout
+	// slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	server := MockServer{}
+	server.Start(t)
+	defer server.Stop(t)
+
+	// Check if we can hit HTTP endpoints
+	httpBaseURL := fmt.Sprintf("http://%s", server.hc.HTTPTarget())
+	t.Run("check success", func(t *testing.T) {
+		checkHTTPPost(t, httpBaseURL)
+		checkHTTPGet(t, httpBaseURL+"/api/v2/checkpoint", "test-checkpoint")
+		checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2", "test-tile:1,2")
+		checkHTTPGet(t, httpBaseURL+"/api/v2/tile/1/2.p/3", "test-tile:1,2.p,3")
+		checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1", "test-entries:1")
+		checkHTTPGet(t, httpBaseURL+"/api/v2/tile/entries/1.p/2", "test-entries:1.p,2")
+	})
+	t.Run("check failures", func(t *testing.T) {
+		checkExtraJSONFieldsErrors(t, httpBaseURL)
+	})
+}
+
+func checkHTTPPost(t *testing.T, httpBaseURL string) {
+	resp, err := http.Post(httpBaseURL+"/api/v2/log/entries", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+		return
+	}
+	entryJSON, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry pbs.TransparencyLogEntry
+	if err = protojson.Unmarshal(entryJSON, &entry); err != nil {
+		t.Fatal(err)
+	}
+	if !proto.Equal(&entry, &testEntry) {
+		t.Errorf("\ngot  :%+v\nwant :%+v", &entry, &testEntry)
+	}
+}
+
+func checkHTTPGet(t *testing.T, url, expectedBody string) {
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf(url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("%s: got %d want %d", url, resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != expectedBody {
+		t.Errorf("%s\ngot  :%q\nwant :%q", url, body, expectedBody)
+	}
+}
+
+// we don't care if fields are missing yet (until we had "REQUIRED" validation), but we should fail for
+// junk fields
+func checkExtraJSONFieldsErrors(t *testing.T, httpBaseURL string) {
+	resp, err := http.Post(httpBaseURL+"/api/v2/log/entries", "application/json", bytes.NewBufferString("{\"foo\":\"bar\"}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+		return
+	}
+
+}

--- a/pkg/server/httpconfig.go
+++ b/pkg/server/httpconfig.go
@@ -14,7 +14,10 @@
 
 package server
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 type HTTPConfig struct {
 	host        string
@@ -52,4 +55,7 @@ func WithHTTPIdleTimeout(idleTimeout time.Duration) HTTPOption {
 	return func(config *HTTPConfig) {
 		config.idleTimeout = idleTimeout
 	}
+}
+func (hc HTTPConfig) HTTPTarget() string {
+	return hc.host + ":" + strconv.Itoa(hc.port)
 }

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -26,6 +26,10 @@ import (
 func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s protobuf.RekorServer) {
 	var wg sync.WaitGroup
 
+	if hc.port == 0 || gc.port == 0 {
+		slog.Error("dynamic port allocation '0' is not supported", "http port", hc.port, "grpc port", gc.port)
+		os.Exit(1)
+	}
 	if hc.port == gc.port && hc.host == gc.host {
 		slog.Error("http and grpc cannot serve at the same address", "host", hc.host, "port", hc.port)
 		os.Exit(1)


### PR DESCRIPTION
Also separate out http and grpc tests and create test fixtures for starting and stopping the server

#### Summary
Most of this is actually moving the tests around so we can check specific behaviors in each server type

#### Release Note
NONE

#### Documentation
NONE