### PR TITLE
Codecov tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
     name: Run unit tests
     permissions:
       contents: read
+      id-token: write # to authenticate with codecov
     runs-on: ubuntu-latest
 
     env:
@@ -81,11 +82,18 @@ jobs:
           check-latest: true
       - name: Run Go tests
         run: go test -covermode atomic -coverprofile coverage.txt $(go list ./... | grep -v third_party/)
+      - name: Workaround buggy Codecov OIDC auth
+        if: github.event_name == 'push'
+        run: |
+          TOKEN_RESPONSE=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://codecov.io")
+          CODECOV_TOKEN=$(echo $TOKEN_RESPONSE | jq -r .value)
+          echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> "$GITHUB_ENV"
       - name: Upload Coverage Report
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           env_vars: OS
           fail_ci_if_error: true
+          # use_oidc: true # does not work: see workaround above
       - name: Run Go tests w/ `-race`
         if: ${{ runner.os == 'Linux' }}
         run: go test -race $(go list ./... | grep -v third_party/)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -84,6 +85,7 @@ jobs:
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           env_vars: OS
+          fail_ci_if_error: true
       - name: Run Go tests w/ `-race`
         if: ${{ runner.os == 'Linux' }}
         run: go test -race $(go list ./... | grep -v third_party/)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,9 @@ jobs:
         with:
           env_vars: OS
           fail_ci_if_error: true
-          # use_oidc: true # does not work: see workaround above
+          # When github.com/codecov/codecov-action/issues/1791 is fixed,
+          # remove workaround step above and uncomment:
+          # use_oidc: true
       - name: Run Go tests w/ `-race`
         if: ${{ runner.os == 'Linux' }}
         run: go test -race $(go list ./... | grep -v third_party/)


### PR DESCRIPTION
* Enable oidc auth for codecov -- use a workaround since the actual auth mechanism is broken
* This adds `id-token: write` permission in the unit-tests job. I think this is ok: test.yml impersonation is not a big issue
* Also add `fail_ci_if_error: true` so we actually notice if the action fails -- we can revert this if failures turn out to be common

I expect that this will fix #104.