### PR TITLE
Add client methods

### DIFF
--- a/pkg/client/option.go
+++ b/pkg/client/option.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "time"
+
+type Config struct {
+	UserAgent string
+	Timeout   time.Duration
+}
+
+type Option func(*Config)
+
+func WithUserAgent(agent string) Option {
+	return func(c *Config) {
+		c.UserAgent = agent
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(c *Config) {
+		c.Timeout = timeout
+	}
+}

--- a/pkg/client/read/read.go
+++ b/pkg/client/read/read.go
@@ -1,0 +1,102 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/sigstore/rekor-tiles/pkg/client"
+	rekornote "github.com/sigstore/rekor-tiles/pkg/note"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/transparency-dev/formats/log"
+	tclient "github.com/transparency-dev/trillian-tessera/client"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// Client reads checkpoints, tiles, and entry bundles from the tile storage service.
+type Client interface {
+	ReadCheckpoint(context.Context) (*log.Checkpoint, *note.Note, error)
+	ReadTile(context.Context, uint64, uint64, uint8) ([]byte, error)
+	ReadEntryBundle(context.Context, uint64, uint8) ([]byte, error)
+}
+
+type readClient struct {
+	baseURL  *url.URL
+	client   *tclient.HTTPFetcher
+	origin   string
+	verifier note.Verifier
+}
+
+// NewReader creates a new reader client.
+func NewReader(readURL, origin string, verifier signature.Verifier, opts ...client.Option) (Client, error) {
+	cfg := &client.Config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	baseURL, err := url.Parse(readURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing url %s: %w", readURL, err)
+	}
+	noteVerifier, err := rekornote.NewNoteVerifier(origin, verifier)
+	if err != nil {
+		return nil, fmt.Errorf("creating note verifier: %w", err)
+	}
+	httpClient := &http.Client{
+		Transport: client.CreateRoundTripper(http.DefaultTransport, cfg.UserAgent),
+		Timeout:   cfg.Timeout,
+	}
+	tileClient, err := tclient.NewHTTPFetcher(baseURL, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("creating tile client: %w", err)
+	}
+	return &readClient{
+		baseURL:  baseURL,
+		client:   tileClient,
+		origin:   origin,
+		verifier: noteVerifier,
+	}, nil
+}
+
+// ReadCheckpoint returns the current checkpoint.
+func (r *readClient) ReadCheckpoint(ctx context.Context) (*log.Checkpoint, *note.Note, error) {
+	readCheckpoint := r.client.ReadCheckpoint
+	cp, _, n, err := tclient.FetchCheckpoint(ctx, readCheckpoint, r.verifier, r.origin)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching checkpoint: %w", err)
+	}
+	return cp, n, nil
+}
+
+// ReadTile returns the tile at the given level, index, and tile segment.
+func (r *readClient) ReadTile(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+	tile, err := r.client.ReadTile(ctx, level, index, p)
+	if err != nil {
+		return nil, fmt.Errorf("reading tile: %w", err)
+	}
+	return tile, nil
+}
+
+// ReadEntryBundle returns the entries at the given index.
+func (r *readClient) ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+	bundle, err := r.client.ReadEntryBundle(ctx, index, p)
+	if err != nil {
+		return nil, fmt.Errorf("reading entry bundle: %w", err)
+	}
+	return bundle, nil
+}

--- a/pkg/client/read/read_test.go
+++ b/pkg/client/read/read_test.go
@@ -1,0 +1,309 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/sigstore/rekor-tiles/pkg/client"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/stretchr/testify/assert"
+)
+
+var ed25519PrivKey = `
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIGuZ8UWTFmXi/26ZgF4VYL8HfLSuW12TN5XMFQRt1Loc
+-----END PRIVATE KEY-----
+`
+
+func TestNewReader(t *testing.T) {
+	readURL := "http://localhost:7080"
+	origin := "rekor-local"
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name     string
+		opts     []client.Option
+		expected *readClient
+	}{
+		{
+			name: "no options",
+			expected: &readClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:7080", Path: "/"},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with user agent",
+			opts: []client.Option{
+				client.WithUserAgent("test"),
+			},
+			expected: &readClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:7080", Path: "/"},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with timeout",
+			opts: []client.Option{
+				client.WithTimeout(1 * time.Second),
+			},
+			expected: &readClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:7080", Path: "/"},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with both",
+			opts: []client.Option{
+				client.WithUserAgent("test"),
+				client.WithTimeout(1 * time.Second),
+			},
+			expected: &readClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:7080", Path: "/"},
+				origin:  "rekor-local",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := NewReader(readURL, origin, verifier, test.opts...)
+			assert.NoError(t, gotErr)
+			assert.Equal(t, test.expected.baseURL, got.(*readClient).baseURL)
+			assert.Equal(t, test.expected.origin, got.(*readClient).origin)
+		})
+	}
+}
+
+func TestReadCheckpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		respBody  []byte
+		respCode  int
+		expectErr bool
+	}{
+		{
+			name: "valid checkpoint",
+			respBody: []byte(`rekor-local
+2
+vABc4Xj1G9UUySBRYDvTZpYtdDqbKN9XthAbY4Nqd/Y=
+
+— rekor-local 2AtEIJwBlAY6KMMNAqcWRKgPZDhP6/bpBmefw4mD89JwL3KozxrLgz7MA8G5pM4UrGNoTOxxpW2bbdv/A5l22ymMLAU=
+`),
+			respCode:  http.StatusOK,
+			expectErr: false,
+		},
+		{
+			name:      "server error",
+			respBody:  []byte("unexpected server error"),
+			respCode:  http.StatusInternalServerError,
+			expectErr: true,
+		},
+		{
+			name: "invalid checkpoint",
+			respBody: []byte(`wrong-origin
+2
+vABc4Xj1G9UUySBRYDvTZpYtdDqbKN9XthAbY4Nqd/Y=
+
+— wrong-origin 2AtEIJwBlAY6KMMNAqcWRKgPZDhP6/bpBmefw4mD89JwL3KozxrLgz7MA8G5pM4UrGNoTOxxpW2bbdv/A5l22ymMLAU=
+`),
+			respCode:  http.StatusOK,
+			expectErr: true,
+		},
+	}
+
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(test.respCode)
+					w.Write(test.respBody)
+				}))
+			defer server.Close()
+			client, err := NewReader(server.URL, "rekor-local", verifier)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotCP, gotNote, gotErr := client.ReadCheckpoint(ctx)
+			if test.expectErr {
+				assert.Error(t, gotErr)
+				return
+			}
+			assert.NoError(t, gotErr)
+			assert.NotNil(t, gotCP)
+			assert.NotNil(t, gotNote)
+		})
+	}
+}
+
+func TestReadTile(t *testing.T) {
+	tests := []struct {
+		name      string
+		tileIndex uint64
+		serverErr bool
+		expectErr bool
+	}{
+		{
+			name:      "server success",
+			tileIndex: 1,
+			expectErr: false,
+		},
+		{
+			name:      "server error",
+			tileIndex: 1,
+			serverErr: true,
+			expectErr: true,
+		},
+		{
+			name:      "out of range",
+			tileIndex: 42,
+			expectErr: true,
+		},
+	}
+
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					treeSize := uint64(10)
+					if test.serverErr {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte("unexpected server error"))
+						return
+					}
+					if test.tileIndex > treeSize {
+						w.WriteHeader(http.StatusNotFound)
+						w.Write([]byte("not found"))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("mozaics"))
+				}))
+			defer server.Close()
+			client, err := NewReader(server.URL, "rekor-local", verifier)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotTile, gotErr := client.ReadTile(ctx, 0, test.tileIndex, 0)
+			if test.expectErr {
+				assert.Error(t, gotErr)
+				return
+			}
+			assert.NoError(t, gotErr)
+			assert.NotNil(t, gotTile)
+		})
+	}
+}
+
+func TestReadEntryBundle(t *testing.T) {
+	tests := []struct {
+		name      string
+		tileIndex uint64
+		serverErr bool
+		expectErr bool
+	}{
+		{
+			name:      "server success",
+			tileIndex: 1,
+			expectErr: false,
+		},
+		{
+			name:      "server error",
+			tileIndex: 1,
+			serverErr: true,
+			expectErr: true,
+		},
+		{
+			name:      "out of range",
+			tileIndex: 42,
+			expectErr: true,
+		},
+	}
+
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					treeSize := uint64(10)
+					if test.serverErr {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte("unexpected server error"))
+						return
+					}
+					if test.tileIndex > treeSize {
+						w.WriteHeader(http.StatusNotFound)
+						w.Write([]byte("not found"))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("mozaics"))
+				}))
+			defer server.Close()
+			client, err := NewReader(server.URL, "rekor-local", verifier)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotTile, gotErr := client.ReadEntryBundle(ctx, test.tileIndex, 0)
+			if test.expectErr {
+				assert.Error(t, gotErr)
+				return
+			}
+			assert.NoError(t, gotErr)
+			assert.NotNil(t, gotTile)
+		})
+	}
+}
+
+func getVerifier(privKey string) (signature.Verifier, error) {
+	block, _ := pem.Decode([]byte(privKey))
+	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := signature.LoadDefaultSignerVerifier(priv.(ed25519.PrivateKey))
+	if err != nil {
+		return nil, err
+	}
+	return verifier, nil
+}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"net/http"
+)
+
+type roundTripper struct {
+	http.RoundTripper
+	userAgent string
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.userAgent != "" {
+		req.Header.Set("User-Agent", rt.userAgent)
+	}
+	return rt.RoundTripper.RoundTrip(req)
+}
+
+func CreateRoundTripper(inner http.RoundTripper, userAgent string) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	if userAgent == "" {
+		return inner
+	}
+	return &roundTripper{
+		RoundTripper: inner,
+		userAgent:    userAgent,
+	}
+}

--- a/pkg/client/write/write.go
+++ b/pkg/client/write/write.go
@@ -1,0 +1,145 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package write
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor-tiles/pkg/client"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	rekornote "github.com/sigstore/rekor-tiles/pkg/note"
+	"github.com/sigstore/rekor-tiles/pkg/verify"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"golang.org/x/mod/sumdb/note"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	addPath = "/api/v2/log/entries"
+)
+
+// Client writes entries to rekor.
+type Client interface {
+	Add(context.Context, any) (*pbs.TransparencyLogEntry, error)
+}
+
+type writeClient struct {
+	baseURL  *url.URL
+	client   *http.Client
+	origin   string
+	verifier note.Verifier
+}
+
+// NewWriter creates a new writer client.
+func NewWriter(writeURL, origin string, verifier signature.Verifier, opts ...client.Option) (Client, error) {
+	cfg := &client.Config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	baseURL, err := url.Parse(writeURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing url %s: %w", writeURL, err)
+	}
+	noteVerifier, err := rekornote.NewNoteVerifier(origin, verifier)
+	if err != nil {
+		return nil, fmt.Errorf("creating note verifier: %w", err)
+	}
+	httpClient := &http.Client{
+		Transport: client.CreateRoundTripper(http.DefaultTransport, cfg.UserAgent),
+		Timeout:   cfg.Timeout,
+	}
+	return &writeClient{
+		baseURL:  baseURL,
+		client:   httpClient,
+		origin:   origin,
+		verifier: noteVerifier,
+	}, nil
+}
+
+// Add uploads a hashedrekord or dsse log entry and returns the TransparencyLogEntry proving the entry's inclusion in the log.
+func (w *writeClient) Add(ctx context.Context, entry any) (*pbs.TransparencyLogEntry, error) {
+	cer, err := createRequest(entry)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	endpoint := *w.baseURL
+	endpoint.Path = path.Join(endpoint.Path, addPath)
+
+	payload, err := protojson.Marshal(cer)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting response: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response: %v %v", resp.StatusCode, string(body))
+	}
+	tle := pbs.TransparencyLogEntry{}
+	err = protojson.Unmarshal(body, &tle)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling response body: %w", err)
+	}
+	if err := verify.VerifyLogEntry(&tle, w.verifier); err != nil {
+		return nil, fmt.Errorf("verifying transparency log entry: %w", err)
+	}
+	return &tle, nil
+}
+
+func createRequest(entry any) (*pb.CreateEntryRequest, error) {
+	switch e := entry.(type) {
+	case *pb.HashedRekordRequest:
+		return createHashedRekordRequest(e), nil
+	case *pb.DSSERequest:
+		return createDSSERequest(e), nil
+	default:
+		return nil, fmt.Errorf("unsupported entry type: %T", entry)
+	}
+}
+
+func createHashedRekordRequest(h *pb.HashedRekordRequest) *pb.CreateEntryRequest {
+	return &pb.CreateEntryRequest{
+		Spec: &pb.CreateEntryRequest_HashedRekordRequest{
+			HashedRekordRequest: h,
+		},
+	}
+}
+
+func createDSSERequest(d *pb.DSSERequest) *pb.CreateEntryRequest {
+	return &pb.CreateEntryRequest{
+		Spec: &pb.CreateEntryRequest_DsseRequest{
+			DsseRequest: d,
+		},
+	}
+}

--- a/pkg/client/write/write_test.go
+++ b/pkg/client/write/write_test.go
@@ -1,0 +1,349 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package write
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor-tiles/pkg/client"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/stretchr/testify/assert"
+)
+
+var ed25519PrivKey = `
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIGuZ8UWTFmXi/26ZgF4VYL8HfLSuW12TN5XMFQRt1Loc
+-----END PRIVATE KEY-----
+`
+
+func TestNewWriter(t *testing.T) {
+	writeURL := "http://localhost:3000"
+	origin := "rekor-local"
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name     string
+		opts     []client.Option
+		expected *writeClient
+	}{
+		{
+			name: "no options",
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3000"},
+				client:  &http.Client{Transport: http.DefaultTransport},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with user agent",
+			opts: []client.Option{
+				client.WithUserAgent("test"),
+			},
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3000"},
+				client:  &http.Client{Transport: client.CreateRoundTripper(nil, "test")},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with timeout",
+			opts: []client.Option{
+				client.WithTimeout(1 * time.Second),
+			},
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3000"},
+				client:  &http.Client{Transport: http.DefaultTransport, Timeout: 1 * time.Second},
+				origin:  "rekor-local",
+			},
+		},
+		{
+			name: "with both",
+			opts: []client.Option{
+				client.WithUserAgent("test"),
+				client.WithTimeout(1 * time.Second),
+			},
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3000"},
+				client: &http.Client{Transport: client.CreateRoundTripper(nil, "test"),
+					Timeout: 1 * time.Second,
+				},
+				origin: "rekor-local",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := NewWriter(writeURL, origin, verifier, test.opts...)
+			assert.NoError(t, gotErr)
+			assert.Equal(t, test.expected.baseURL, got.(*writeClient).baseURL)
+			assert.Equal(t, test.expected.client, got.(*writeClient).client)
+			assert.Equal(t, test.expected.origin, got.(*writeClient).origin)
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name      string
+		entry     any
+		respBody  []byte
+		respCode  int
+		expectErr error
+	}{
+		{
+			name: "valid hashedrekord",
+			entry: &pb.HashedRekordRequest{
+				Signature: []byte("sign"),
+				Data: &v1.HashOutput{
+					Algorithm: v1.HashAlgorithm(v1.HashAlgorithm_SHA2_256),
+					Digest:    []byte("digest"),
+				},
+				Verifier: &pb.Verifier{
+					Verifier: &pb.Verifier_PublicKey{
+						PublicKey: &pb.PublicKey{
+							RawBytes: []byte("key"),
+						},
+					},
+				},
+			},
+			respBody: marshalJSONOrDie(t, pbs.TransparencyLogEntry{
+				LogIndex: 1,
+				InclusionProof: &pbs.InclusionProof{
+					LogIndex: 1,
+					RootHash: b64DecodeOrDie(t, "NmVmNWM2YzY2NzcxNjI0YmZmMDI1ZDRmMGNkODRkYWVmYjI0MzIzMzk4MmU5MDA5M2Y0NDBkNDM5ODliY2ZiYgo="),
+					TreeSize: 2,
+					Hashes: [][]byte{
+						b64DecodeOrDie(t, "d/XeBMMsM7fy/gMiRBFow5u6dOud2RFlKQy20qNSB8w="),
+					},
+					Checkpoint: &pbs.Checkpoint{
+						Envelope: "rekor-local\n2\nbvXGxmdxYkv/Al1PDNhNrvskMjOYLpAJP0QNQ5ibz7s=\n\n— rekor-local 2AtEIKMQNqn1+JpFEwM4yv/nDtVtu0B6yGRkOLpbHP9tQMF493hYOgRKUhp9ZNylWSJebqOThUpdO03LzJn3/6K5HQc=\n",
+					},
+				},
+				CanonicalizedBody: []byte(`{"data":{"algorithm":"SHA2_256","digest":"ZGlnZXN0"},"signature":"c2lnbg==","verifier":{"publicKey":{"rawBytes":"a2V5"}}}`),
+			}),
+			respCode:  http.StatusCreated,
+			expectErr: nil,
+		},
+		{
+			name: "valid dsse",
+			entry: &pb.DSSERequest{
+				Envelope: "dsse",
+				Verifier: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte("key"),
+							},
+						},
+					},
+				},
+			},
+			respBody: marshalJSONOrDie(t, pbs.TransparencyLogEntry{
+				LogIndex: 1,
+				InclusionProof: &pbs.InclusionProof{
+					RootHash: b64DecodeOrDie(t, "YmMwMDVjZTE3OGY1MWJkNTE0YzkyMDUxNjAzYmQzNjY5NjJkNzQzYTliMjhkZjU3YjYxMDFiNjM4MzZhNzdmNg=="),
+
+					TreeSize: 2,
+					Hashes: [][]byte{
+						b64DecodeOrDie(t, "wWB4RFtzi4KkguQYjzcUge9No4fwgGMVdtQt6ls5B0I="),
+					},
+					Checkpoint: &pbs.Checkpoint{
+						Envelope: "rekor-local\n2\nvABc4Xj1G9UUySBRYDvTZpYtdDqbKN9XthAbY4Nqd/Y=\n\n— rekor-local 2AtEIJwBlAY6KMMNAqcWRKgPZDhP6/bpBmefw4mD89JwL3KozxrLgz7MA8G5pM4UrGNoTOxxpW2bbdv/A5l22ymMLAU=\n",
+					},
+				},
+				CanonicalizedBody: []byte(`{"envelope":"dsse","verifier":[{"publicKey":{"rawBytes":"a2V5"}}]}`),
+			}),
+			respCode:  http.StatusCreated,
+			expectErr: nil,
+		},
+		{
+			name:      "invalid entry type",
+			entry:     "intoto entry",
+			expectErr: fmt.Errorf("unsupported entry type: string"),
+		},
+		{
+			name: "server error",
+			entry: &pb.DSSERequest{
+				Envelope: "dsse",
+				Verifier: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte("key"),
+							},
+						},
+					},
+				},
+			},
+			respBody:  []byte("server died"),
+			respCode:  http.StatusInternalServerError,
+			expectErr: fmt.Errorf("unexpected response: 500 server died"),
+		},
+		{
+			name: "unexpected response body from server",
+			entry: &pb.DSSERequest{
+				Envelope: "dsse",
+				Verifier: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte("key"),
+							},
+						},
+					},
+				},
+			},
+			respBody:  []byte("i love ice cream"),
+			respCode:  http.StatusCreated,
+			expectErr: fmt.Errorf("unmarshaling response body: proto"),
+		},
+		{
+			name: "invalid checkpoint",
+			entry: &pb.DSSERequest{
+				Envelope: "dsse",
+				Verifier: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte("key"),
+							},
+						},
+					},
+				},
+			},
+			respBody: marshalJSONOrDie(t, pbs.TransparencyLogEntry{
+				LogIndex: 1,
+				InclusionProof: &pbs.InclusionProof{
+					RootHash: b64DecodeOrDie(t, "YmMwMDVjZTE3OGY1MWJkNTE0YzkyMDUxNjAzYmQzNjY5NjJkNzQzYTliMjhkZjU3YjYxMDFiNjM4MzZhNzdmNg=="),
+
+					TreeSize: 2,
+					Hashes: [][]byte{
+						b64DecodeOrDie(t, "wWB4RFtzi4KkguQYjzcUge9No4fwgGMVdtQt6ls5B0I="),
+					},
+					Checkpoint: &pbs.Checkpoint{
+						Envelope: "wrong-origin\n2\nvABc4Xj1G9UUySBRYDvTZpYtdDqbKN9XthAbY4Nqd/Y=\n\n— rekor-local 2AtEIJwBlAY6KMMNAqcWRKgPZDhP6/bpBmefw4mD89JwL3KozxrLgz7MA8G5pM4UrGNoTOxxpW2bbdv/A5l22ymMLAU=\n",
+					},
+				},
+				CanonicalizedBody: []byte(`{"envelope":"dsse","verifier":[{"publicKey":{"rawBytes":"a2V5"}}]}`),
+			}),
+			respCode:  http.StatusCreated,
+			expectErr: fmt.Errorf("verifying transparency log entry: unverified checkpoint signature: failed to verify signatures on checkpoint: invalid signature for key"),
+		},
+		{
+			name: "invalid inclusion proof",
+			entry: &pb.DSSERequest{
+				Envelope: "dsse",
+				Verifier: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte("key"),
+							},
+						},
+					},
+				},
+			},
+			respBody: marshalJSONOrDie(t, pbs.TransparencyLogEntry{
+				LogIndex: 1,
+				InclusionProof: &pbs.InclusionProof{
+					RootHash: b64DecodeOrDie(t, "YmMwMDVjZTE3OGY1MWJkNTE0YzkyMDUxNjAzYmQzNjY5NjJkNzQzYTliMjhkZjU3YjYxMDFiNjM4MzZhNzdmNg=="),
+
+					TreeSize: 2,
+					Hashes:   [][]byte{},
+					Checkpoint: &pbs.Checkpoint{
+						Envelope: "rekor-local\n2\nvABc4Xj1G9UUySBRYDvTZpYtdDqbKN9XthAbY4Nqd/Y=\n\n— rekor-local 2AtEIJwBlAY6KMMNAqcWRKgPZDhP6/bpBmefw4mD89JwL3KozxrLgz7MA8G5pM4UrGNoTOxxpW2bbdv/A5l22ymMLAU=\n",
+					},
+				},
+				CanonicalizedBody: []byte(`{"envelope":"dsse","verifier":[{"publicKey":{"rawBytes":"a2V5"}}]}`),
+			}),
+			respCode:  http.StatusCreated,
+			expectErr: fmt.Errorf("verifying transparency log entry: verifying inclusion: "),
+		},
+	}
+
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(test.respCode)
+					w.Write([]byte(test.respBody))
+				}))
+			defer server.Close()
+			client, err := NewWriter(server.URL, "rekor-local", verifier)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, gotErr := client.Add(ctx, test.entry)
+			if test.expectErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
+			}
+		})
+	}
+}
+
+func b64DecodeOrDie(t *testing.T, text string) []byte {
+	decoded, err := base64.StdEncoding.DecodeString(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func marshalJSONOrDie(t *testing.T, obj any) []byte {
+	marshaledResp, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return marshaledResp
+}
+
+func getVerifier(privKey string) (signature.Verifier, error) {
+	block, _ := pem.Decode([]byte(privKey))
+	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := signature.LoadDefaultSignerVerifier(priv.(ed25519.PrivateKey))
+	if err != nil {
+		return nil, err
+	}
+	return verifier, nil
+}


### PR DESCRIPTION
Add a client support package. This will be used in Rekor's integration tests and can be imported by Go-based Sigstore clients.

Depends on #119 

TODO:

- [x] verify inclusion proof from Add response
- [x] add ReadCheckpoint
- [x] add ReadTile
- [x] add ReadEntryBundle
- [x] remove `verifyTLE` and replace with verification functions from https://github.com/sigstore/rekor-tiles/pull/114
- [x] add unit tests

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
