### PR TITLE
Make SafeInt64 public

### DIFF
--- a/pkg/tessera/safeint.go
+++ b/pkg/tessera/safeint.go
@@ -20,13 +20,13 @@ import (
 	"math"
 )
 
-// safeInt64 holds equivalent int64 and uint64 integers.
-type safeInt64 struct {
+// SafeInt64 holds equivalent int64 and uint64 integers.
+type SafeInt64 struct {
 	u uint64
 	i int64
 }
 
-// newSafeInt64 returns a safeInt64 struct as long as the number is either an
+// NewSafeInt64 returns a safeInt64 struct as long as the number is either an
 // int64 or uint64 and the value can safely be converted in either direction
 // without overflowing, i.e. is not greater than MaxInt64 and not negative.
 //
@@ -36,8 +36,8 @@ type safeInt64 struct {
 //
 // This is needed for compatibility with TransparencyLogEntry
 // (https://github.com/sigstore/protobuf-specs/blob/e871d3e6fd06fa73a1524ef0efaf1452d3304cf6/protos/sigstore_rekor.proto#L86-L138).
-func newSafeInt64(number any) (*safeInt64, error) {
-	var result safeInt64
+func NewSafeInt64(number any) (*SafeInt64, error) {
+	var result SafeInt64
 	switch n := number.(type) {
 	case uint64:
 		if n > math.MaxInt64 {
@@ -55,4 +55,14 @@ func newSafeInt64(number any) (*safeInt64, error) {
 		return nil, fmt.Errorf("only uint64 and int64 are supported")
 	}
 	return &result, nil
+}
+
+// U returns the uint64 value of the integer.
+func (s *SafeInt64) U() uint64 {
+	return s.u
+}
+
+// I returns the int64 value of the integer.
+func (s *SafeInt64) I() int64 {
+	return s.i
 }

--- a/pkg/tessera/safeint_test.go
+++ b/pkg/tessera/safeint_test.go
@@ -23,22 +23,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_newSafeInt64(t *testing.T) {
+func TestNewSafeInt64(t *testing.T) {
 	tests := []struct {
 		name      string
 		number    any
-		expect    *safeInt64
+		expect    *SafeInt64
 		expectErr error
 	}{
 		{
 			name:   "small uint",
 			number: uint64(42),
-			expect: &safeInt64{u: uint64(42), i: int64(42)},
+			expect: &SafeInt64{u: uint64(42), i: int64(42)},
 		},
 		{
 			name:   "small positive int",
 			number: int64(42),
-			expect: &safeInt64{u: uint64(42), i: int64(42)},
+			expect: &SafeInt64{u: uint64(42), i: int64(42)},
 		},
 		{
 			name:      "too large uint",
@@ -67,7 +67,7 @@ func Test_newSafeInt64(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := newSafeInt64(test.number)
+			got, gotErr := NewSafeInt64(test.number)
 			assert.Equal(t, test.expect, got)
 			assert.Equal(t, test.expectErr, gotErr)
 		})


### PR DESCRIPTION
Expose the uint64<->int64 conversion type so it can be used more widely over the code base.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
