### PR TITLE
Add metrics

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -82,7 +82,8 @@ var serveCmd = &cobra.Command{
 			ctx,
 			server.NewHTTPConfig(
 				server.WithHTTPPort(viper.GetInt("http-port")),
-				server.WithHTTPHost(viper.GetString("http-address"))),
+				server.WithHTTPHost(viper.GetString("http-address")),
+				server.WithHTTPMetricsPort(viper.GetInt("http-metrics-port"))),
 			server.NewGRPCConfig(
 				server.WithGRPCPort(viper.GetInt("grpc-port")),
 				server.WithGRPCHost(viper.GetString("grpc-address"))),
@@ -95,6 +96,7 @@ func init() {
 	// server configs
 	serveCmd.Flags().Int("http-port", 3000, "HTTP port to bind to")
 	serveCmd.Flags().String("http-address", "127.0.0.1", "HTTP address to bind to")
+	serveCmd.Flags().Int("http-metrics-port", 2112, "HTTP port to bind metrics to")
 	serveCmd.Flags().Int("grpc-port", 3001, "GRPC port to bind to")
 	serveCmd.Flags().String("grpc-address", "127.0.0.1", "GRPC address to bind to")
 	hostname, err := os.Hostname()

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,7 @@ services:
     - "--signer-filepath=/pki/ed25519-priv-key.pem"
     ports:
     - "3000:3000"
+    - "2112:2112" # metrics port
     healthcheck:
       test:
       - CMD-SHELL

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.24.0
 
 require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
+	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
+	github.com/prometheus/client_golang v1.20.5
 	github.com/sigstore/protobuf-specs v0.4.0
 	github.com/sigstore/sigstore v1.9.2-0.20250311183026-c049f8ddc600
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.9.2-0.20250311183026-c049f8ddc600
@@ -67,6 +69,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 // indirect
 	github.com/aws/smithy-go v1.22.3 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3 // indirect
@@ -88,6 +91,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.5 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -102,18 +106,22 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jellydator/ttlcache/v3 v3.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/common v0.55.0 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
@@ -149,7 +157,6 @@ require (
 	google.golang.org/genproto v0.0.0-20250122153221-138b5a5a4fd4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -920,6 +920,10 @@ github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrk
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwnKaMyD8uC+34TLdndZMAKk=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
@@ -978,6 +982,8 @@ github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -45,9 +45,10 @@ type grpcServer struct {
 }
 
 func newGRPCService(config *GRPCConfig, server pb.RekorServer) *grpcServer {
-	// Create a gRPC Server object
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.ChainUnaryInterceptor(getMetrics().serverMetrics.UnaryServerInterceptor()))
 	pb.RegisterRekorServer(s, server)
+
+	getMetrics().serverMetrics.InitializeMetrics(s)
 
 	return &grpcServer{s, fmt.Sprintf("%s:%v", config.host, config.port)}
 }

--- a/pkg/server/httpconfig.go
+++ b/pkg/server/httpconfig.go
@@ -23,6 +23,7 @@ type HTTPConfig struct {
 	host        string
 	idleTimeout time.Duration
 	port        int
+	metricsPort int
 }
 type HTTPOption func(config *HTTPConfig)
 
@@ -31,6 +32,7 @@ func NewHTTPConfig(options ...func(config *HTTPConfig)) *HTTPConfig {
 		host:        "localhost",
 		idleTimeout: 60 * time.Second,
 		port:        8080,
+		metricsPort: 2112,
 	}
 	for _, opt := range options {
 		opt(config)
@@ -56,6 +58,15 @@ func WithHTTPIdleTimeout(idleTimeout time.Duration) HTTPOption {
 		config.idleTimeout = idleTimeout
 	}
 }
+
+func WithHTTPMetricsPort(port int) HTTPOption {
+	return func(config *HTTPConfig) {
+		config.metricsPort = port
+	}
+}
+
 func (hc HTTPConfig) HTTPTarget() string {
 	return hc.host + ":" + strconv.Itoa(hc.port)
 }
+
+func (hc HTTPConfig) HTTPMetricsTarget() string { return hc.host + ":" + strconv.Itoa(hc.metricsPort) }

--- a/pkg/server/httpconfig_test.go
+++ b/pkg/server/httpconfig_test.go
@@ -31,6 +31,15 @@ func TestNewHTTPConfig(t *testing.T) {
 	if config.port != 8080 {
 		t.Errorf("Expected port to be 8080, got %d", config.port)
 	}
+	if config.metricsPort != 2112 {
+		t.Errorf("Expected metricsport to be 2112, got %d", config.port)
+	}
+	if config.HTTPTarget() != "localhost:8080" {
+		t.Errorf("Expected http target to be localhost:8080, got %s", config.HTTPTarget())
+	}
+	if config.HTTPMetricsTarget() != "localhost:2112" {
+		t.Errorf("Expected http metrics target to be localhost:2112, got %s", config.HTTPTarget())
+	}
 }
 
 func TestWithHTTPPort(t *testing.T) {
@@ -54,19 +63,36 @@ func TestWithHTTPIdleTimeout(t *testing.T) {
 	}
 }
 
+func TestWithHTTPMetricsPort(t *testing.T) {
+	config := NewHTTPConfig(WithHTTPMetricsPort(9001))
+	if config.metricsPort != 9001 {
+		t.Errorf("Expected metrics port to be 9001, got %d", config.port)
+	}
+}
+
 func TestMultipleOptions(t *testing.T) {
 	config := NewHTTPConfig(
 		WithHTTPPort(9090),
 		WithHTTPHost("test.example.com"),
 		WithHTTPIdleTimeout(10*time.Second),
+		WithHTTPMetricsPort(9091),
 	)
 	if config.port != 9090 {
 		t.Errorf("Expected port to be 9090, got %d", config.port)
+	}
+	if config.metricsPort != 9091 {
+		t.Errorf("Expected port to be 9091, got %d", config.port)
 	}
 	if config.host != "test.example.com" {
 		t.Errorf("Expected host to be test.example.com, got %s", config.host)
 	}
 	if config.idleTimeout != 10*time.Second {
 		t.Errorf("Expected idleTimeout to be 10s, got %v", config.idleTimeout)
+	}
+	if config.HTTPTarget() != "test.example.com:9090" {
+		t.Errorf("Expected http target to be test.example.com:9090, got %s", config.HTTPTarget())
+	}
+	if config.HTTPMetricsTarget() != "test.example.com:9091" {
+		t.Errorf("Expected http metrics target to be test.example.com:9091, got %s", config.HTTPTarget())
 	}
 }

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -1,0 +1,163 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"sigs.k8s.io/release-utils/version"
+)
+
+type metrics struct {
+	reg           *prometheus.Registry
+	serverMetrics *grpc_prometheus.ServerMetrics
+	// metrics
+	newHashedRekordEntries prometheus.Counter
+	newDsseEntries         prometheus.Counter
+	httpLatency            *prometheus.HistogramVec
+	httpRequestsCount      *prometheus.CounterVec
+}
+
+// Metrics provides the singleton metrics instance
+func getMetrics() *metrics {
+	return _initMetricsFunc()
+}
+
+var _initMetricsFunc = sync.OnceValue[*metrics](func() *metrics {
+	m := metrics{
+		reg:           prometheus.NewRegistry(),
+		serverMetrics: grpc_prometheus.NewServerMetrics(),
+	}
+	m.reg.MustRegister(m.serverMetrics)
+
+	f := promauto.With(m.reg)
+
+	m.newHashedRekordEntries = f.NewCounter(prometheus.CounterOpts{
+		Name: "rekor_new_hashedrekord_entries",
+		Help: "The total number of new dsse log entries",
+	})
+
+	m.newDsseEntries = f.NewCounter(prometheus.CounterOpts{
+		Name: "rekor_new_dsse_entries",
+		Help: "The total number of new dsse log entries",
+	})
+
+	m.httpLatency = f.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "rekor_http_api_latency",
+		Help: "API Latency on HTTP calls",
+	}, []string{"code", "method"})
+
+	m.httpRequestsCount = f.NewCounterVec(prometheus.CounterOpts{
+		Name: "rekor_http_requests_total",
+		Help: "Count all HTTP requests",
+	}, []string{"code", "method"})
+
+	// TODO(appu): add metrics from rekor v1 (anything but Counter appears to need to be a pointer)
+	// https://github.com/sigstore/rekor-tiles/issues/123
+
+	_ = f.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: "rekor_v2",
+			Name:      "build_info",
+			Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which rekor was built.",
+			ConstLabels: prometheus.Labels{
+				"version":    version.GetVersionInfo().GitVersion,
+				"revision":   version.GetVersionInfo().GitCommit,
+				"build_date": version.GetVersionInfo().BuildDate,
+				"goversion":  version.GetVersionInfo().GoVersion,
+			},
+		},
+		func() float64 { return 1 },
+	)
+	return &m
+})
+
+type httpMetrics struct {
+	*http.Server
+	serverEndpoint string
+}
+
+func newHTTPMetrics(_ context.Context, config *HTTPConfig) *httpMetrics {
+	mux := http.NewServeMux()
+	mux.Handle("/", promhttp.HandlerFor(getMetrics().reg, promhttp.HandlerOpts{}))
+
+	// TODO: configure https connection preferences (time-out, max size, etc)
+
+	endpoint := config.HTTPMetricsTarget()
+	return &httpMetrics{
+		Server: &http.Server{
+			Addr:    endpoint,
+			Handler: mux,
+
+			ReadTimeout:       60 * time.Second,
+			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       config.idleTimeout,
+		},
+		serverEndpoint: endpoint,
+	}
+}
+
+func (hp *httpMetrics) start(wg *sync.WaitGroup) {
+
+	lis, err := net.Listen("tcp", hp.serverEndpoint)
+	if err != nil {
+		slog.Error("failed to create listener:", "errors", err)
+		os.Exit(1)
+	}
+
+	hp.serverEndpoint = lis.Addr().String()
+
+	slog.Info("starting http metrics", "address", hp.serverEndpoint)
+
+	waitToClose := make(chan struct{})
+	go func() {
+		// capture interrupts and shutdown Server
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, syscall.SIGINT, syscall.SIGTERM)
+		<-sigint
+
+		if err := hp.Shutdown(context.Background()); err != nil {
+			slog.Info("http metrics Server Shutdown error", "errors", err)
+		}
+		close(waitToClose)
+		slog.Info("stopped http metrics Server")
+	}()
+
+	wg.Add(1)
+	go func() {
+
+		if err := hp.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("could not start http metrics server", "errors", err)
+			os.Exit(1)
+		}
+		<-waitToClose
+		wg.Done()
+		slog.Info("http metrics Server shutdown")
+	}()
+}

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestServe_httpMetricsSmoke(t *testing.T) {
+	// To debug set slog to output to stdout
+	// slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	server := MockServer{}
+	server.Start(t)
+	defer server.Stop(t)
+
+	// Check if we can hit the metrics endpoint
+	metricsURL := fmt.Sprintf("http://%s", server.hc.HTTPMetricsTarget())
+
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		t.Fatalf(metricsURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("%s: got %d want %d", metricsURL, resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := string(body)
+	expectedMetrics := []string{
+		"rekor_new_hashedrekord_entries",
+		"rekor_new_dsse_entries",
+		"build_info",
+		"rekor_http_api_latency",
+		"rekor_http_requests_total",
+		"grpc_server_started_total", // should imply we have the default set of grpc server metrics
+		"promhttp_metric_handler",   // should imply we have the default set of promhttp metrics
+	}
+
+	for _, metric := range expectedMetrics {
+		if !strings.Contains(b, metric) {
+			t.Errorf("metrics target body did not contain %s, \n %s", metric, body)
+		}
+	}
+}

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -41,5 +41,8 @@ func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s protobuf.Rekor
 	httpProxy := newHTTPProxy(ctx, hc, grpcServer)
 	httpProxy.start(&wg)
 
+	httpMetrics := newHTTPMetrics(ctx, hc)
+	httpMetrics.start(&wg)
+
 	wg.Wait()
 }

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
@@ -40,12 +42,15 @@ type Server struct {
 }
 
 func NewServer(storage tessera.Storage) *Server {
-	return &Server{storage: storage}
+	return &Server{
+		storage: storage,
+	}
 }
 
 func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*pbs.TransparencyLogEntry, error) {
 	var serialized []byte
 	var err error
+	var metricsCounter prometheus.Counter
 	switch req.GetSpec().(type) {
 	case *pb.CreateEntryRequest_HashedRekordRequest:
 		hr := req.GetHashedRekordRequest()
@@ -58,6 +63,7 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 			slog.Warn("failed marshaling hashedrekord request", "error", err.Error())
 			return nil, status.Errorf(codes.InvalidArgument, "invalid hashedrekord request")
 		}
+		metricsCounter = getMetrics().newHashedRekordEntries
 	case *pb.CreateEntryRequest_DsseRequest:
 		ds := req.GetDsseRequest()
 		if err := dsse.Validate(ds); err != nil {
@@ -69,6 +75,7 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 			slog.Warn("failed marshaling dsse request", "error", err.Error())
 			return nil, status.Errorf(codes.InvalidArgument, "invalid dsse request")
 		}
+		metricsCounter = getMetrics().newDsseEntries
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "invalid type, must be either hashedrekord or dsse")
 	}
@@ -84,6 +91,7 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 		return nil, status.Errorf(codes.Unknown, "failed to integrate entry")
 	}
 	_ = grpc.SetHeader(ctx, metadata.Pairs(httpStatusHeader, "201"))
+	metricsCounter.Inc()
 	return tle, nil
 }
 


### PR DESCRIPTION
Add default metrics to grpc and http servers
Add some rudimentary metrics for counting new entries

Serve metrics on (default) 0.0.0.0:2112 or <host>:<metrics-port>

#### Summary
fixes #124 

Adds prometheus config

Endpoints using configs should add new metric types to metrics, and increment them (or whatever) by using the singleton instance provided by `getMetrics()`

to see metrics in action:
```
docker-compose up
curl localhost:2112
```

#### Release Note
NONE

#### Documentation
NONE