### PR TITLE
workflows: Tweak oidc auth for codecov once more

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,10 @@ jobs:
       - name: Run Go tests
         run: go test -covermode atomic -coverprofile coverage.txt $(go list ./... | grep -v third_party/)
       - name: Workaround buggy Codecov OIDC auth
-        if: github.event_name == 'push'
         run: |
+          # only set CODECOV_TOKEN if OIDC token is available
+          [ -z $ACTIONS_ID_TOKEN_REQUEST_TOKEN ] && exit 0
+
           TOKEN_RESPONSE=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://codecov.io")
           CODECOV_TOKEN=$(echo $TOKEN_RESPONSE | jq -r .value)
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> "$GITHUB_ENV"


### PR DESCRIPTION
Currently codecov step succeeds in main and in PRs from forks, but fails in PRs from origin. This seems to be a codecov bug but I believe we can tweak the workaround a bit.

* Always run the auth workaround step
* Only try to set the codecov token if OIDC is available

This should mean that:
* PRs from forks will not have auth token: that works fine
* pushes to main will have auth token
* PRs from origin repo will have auth token (even though they should not need it)
