### PR TITLE
Return canonicalized body in server response

### DIFF
--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -77,8 +77,9 @@ func (s *storage) Add(ctx context.Context, entry *tessera.Entry) (*rekor_pb.Tran
 		return nil, fmt.Errorf("building inclusion proof: %w", err)
 	}
 	return &rekor_pb.TransparencyLogEntry{
-		LogIndex:       idx.I(),
-		InclusionProof: inclusionProof,
+		LogIndex:          idx.I(),
+		InclusionProof:    inclusionProof,
+		CanonicalizedBody: entry.Data(),
 	}, nil
 }
 

--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -52,6 +52,7 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 		expectLogIndex int64
 		expectTreeSize int64
 		expectHash     []byte
+		expectBody     []byte
 	}{
 		{
 			name: "success",
@@ -61,6 +62,14 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 			expectLogIndex: int64(0),
 			expectTreeSize: int64(1),
 			expectHash:     []byte(tileHash),
+			expectBody:     []byte("stuff"),
+		},
+		{
+			name: "integration failed",
+			addFn: func(_ context.Context, _ *tessera.Entry) tessera.IndexFuture {
+				return func() (uint64, error) { return 0, fmt.Errorf("server error") }
+			},
+			expectErr: fmt.Errorf("add entry: await: server error"),
 		},
 	}
 	for _, test := range tests {
@@ -69,12 +78,13 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 			got, gotErr := s.Add(ctx, entry)
 			if test.expectErr != nil {
 				assert.ErrorContains(t, gotErr, test.expectErr.Error())
-			} else {
-				assert.NoError(t, gotErr)
+				return
 			}
+			assert.NoError(t, gotErr)
 			assert.Equal(t, test.expectLogIndex, got.LogIndex)
 			assert.Equal(t, test.expectTreeSize, got.InclusionProof.TreeSize)
 			assert.Equal(t, test.expectHash, got.InclusionProof.RootHash)
+			assert.Equal(t, test.expectBody, got.CanonicalizedBody)
 		})
 	}
 }


### PR DESCRIPTION
Also add failure case to the unit test.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
