### PR TITLE
Fix unit test error checking

### DIFF
--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -68,7 +68,7 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 			s.addFn = test.addFn
 			got, gotErr := s.Add(ctx, entry)
 			if test.expectErr != nil {
-				assert.Errorf(t, gotErr, test.expectErr.Error())
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
 			} else {
 				assert.NoError(t, gotErr)
 			}
@@ -121,7 +121,7 @@ func TestReadTile(t *testing.T) {
 			got, gotErr := s.ReadTile(ctx, test.level, test.index, test.p)
 			assert.Equal(t, test.expectHash, got)
 			if test.expectErr != nil {
-				assert.Errorf(t, gotErr, test.expectErr.Error())
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
 			} else {
 				assert.NoError(t, gotErr)
 			}

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -72,7 +72,7 @@ func TestValidate(t *testing.T) {
 			if test.expectErr == nil {
 				assert.NoError(t, gotErr)
 			} else {
-				assert.Errorf(t, gotErr, test.expectErr.Error())
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
 			}
 		})
 	}

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -107,7 +107,7 @@ func TestValidate(t *testing.T) {
 			if test.expectErr == nil {
 				assert.NoError(t, gotErr)
 			} else {
-				assert.Errorf(t, gotErr, test.expectErr.Error())
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
 			}
 		})
 	}

--- a/pkg/types/verifier/verifier_test.go
+++ b/pkg/types/verifier/verifier_test.go
@@ -79,7 +79,7 @@ func TestValidate(t *testing.T) {
 			if test.expectErr == nil {
 				assert.NoError(t, gotErr)
 			} else {
-				assert.Errorf(t, gotErr, test.expectErr.Error())
+				assert.ErrorContains(t, gotErr, test.expectErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
`assert.Errorf` doesn't actually check the error message, `assert.ErrorContains` does that.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
