### PR TITLE
dependabot: Group patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      go-patch-updates:
+        update-types:
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-patch-updates:
+        update-types:
+          - "patch"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker-patch-updates:
+        update-types:
+          - "patch"


### PR DESCRIPTION
This only groups patch level updates: this might not do that much considering the inconsistent version numbering used in the relevant ecosystems... We could add "minor" updates too but then there's more chance of broken dependebot group updates
