### PR TITLE
feat: add log timestamps to init.sh

### DIFF
--- a/config/emulator_init.sh
+++ b/config/emulator_init.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+PS4='+\D{%Y-%m-%d %H:%M:%S} $LINENO: '
+
+set -eux
 
 gcloud config configurations list | grep emulator | grep True || gcloud config configurations create emulator
 gcloud config set auth/disable_credentials true


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds timestamps to init.sh

```
 *  Executing task: docker logs --tail 1000 -f 1aa3ce4a772ac814f2ad823b8aed046933cf664b4b6d33ffdfd8d254925a1ee6 

+2025-03-24 20:09:31 21: gcloud config configurations list
+2025-03-24 20:09:31 21: grep emulator
+2025-03-24 20:09:31 21: grep True
+2025-03-24 20:09:34 21: gcloud config configurations create emulator
Created [emulator].
Activated [emulator].
+2025-03-24 20:09:35 22: gcloud config set auth/disable_credentials true
Updated property [auth/disable_credentials].
+2025-03-24 20:09:35 23: gcloud config set project rekor-tiles-e2e
Updated property [core/project].
+2025-03-24 20:09:36 24: gcloud config set api_endpoint_overrides/spanner http://spanner:9020/
WARNING: The value set for [api_endpoint_overrides/spanner] was found to be associated with a universe domain outside of the current config universe [googleapis.com]. Please create a new gcloud configuration for each universe domain you make requests to using `gcloud config configurations create` with the `--universe-domain` flag or switch to a configuration associated with [http://spanner:9020/].
Updated property [api_endpoint_overrides/spanner].
+2025-03-24 20:09:37 26: gcloud spanner instances list
+2025-03-24 20:09:37 26: grep rekor-tiles
Listed 0 items.
+2025-03-24 20:09:38 27: gcloud spanner instances create rekor-tiles --no-user-output-enabled --nodes=1 '--description=test spanner instance for rekor tiles' --config=emulator-config
+2025-03-24 20:09:39 32: gcloud spanner databases list --instance rekor-tiles
+2025-03-24 20:09:39 32: grep sequencer
Listed 0 items.
+2025-03-24 20:09:40 33: gcloud spanner databases create sequencer --no-user-output-enabled --instance rekor-tiles
+2025-03-24 20:09:42 37: echo done
 *  Terminal will be reused by tasks, press any key to close it. 

```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
