### PR TITLE
Expose Tessera append lifecycle options

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -58,6 +58,7 @@ services:
     - "--gcp-bucket=tiles"
     - "--gcp-spanner=projects/rekor-tiles-e2e/instances/rekor-tiles/databases/sequencer"
     - "--signer-filepath=/pki/ed25519-priv-key.pem"
+    - "--checkpoint-interval=2s"
     ports:
     - "3000:3000" # http port
     - "3001:3001" # grpc port

--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
 	tessera "github.com/transparency-dev/trillian-tessera"
 )
@@ -137,4 +138,17 @@ func TestReadTile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewAppendOptions(t *testing.T) {
+	sv, _, err := signature.NewDefaultECDSASignerVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ao, err := NewAppendOptions(context.Background(), "test", sv, 42, 42*time.Millisecond, 42*time.Second, 42)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(42), ao.BatchMaxSize())
+	assert.Equal(t, 42*time.Millisecond, ao.BatchMaxAge())
+	assert.Equal(t, 42*time.Second, ao.CheckpointInterval())
+	assert.Equal(t, uint(42), ao.PushbackMaxOutstanding())
 }


### PR DESCRIPTION
Expose Tessera's batch size, batch age, checkpoint interval, and pushback options through Rekor's configuration. This will enable us to tune the server to balance the cost and latency of sequencing entries, and in particular it will allow us to reduce the time to publish a new checkpoint so that entries added sequentially in tests no longer need to wait up to 10 seconds for a response.

Fixes https://github.com/sigstore/rekor-tiles/issues/148

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
