### PR TITLE
Add entry hash algorithm config and validation

### DIFF
--- a/pkg/algorithmregistry/algorithmregistry.go
+++ b/pkg/algorithmregistry/algorithmregistry.go
@@ -1,0 +1,82 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package algorithmregistry
+
+import (
+	"crypto"
+	"fmt"
+
+	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/rekor-tiles/pkg/pki/x509"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+var (
+	AllowedClientSigningAlgorithms = []v1.PublicKeyDetails{
+		v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_2048_SHA256,
+		v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_3072_SHA256,
+		v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256,
+		v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+		v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384,
+		v1.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
+		v1.PublicKeyDetails_PKIX_ED25519,
+		v1.PublicKeyDetails_PKIX_ED25519_PH,
+	}
+)
+
+// AlgorithmRegistry accepts a list of algorithms as strings, parses and formats them into a registry.
+func AlgorithmRegistry(algorithmOptions []string) (*signature.AlgorithmRegistryConfig, error) {
+	var algorithms []v1.PublicKeyDetails
+	if algorithmOptions == nil {
+		algorithms = AllowedClientSigningAlgorithms
+	} else {
+		for _, a := range algorithmOptions {
+			algorithm, err := signature.ParseSignatureAlgorithmFlag(a)
+			if err != nil {
+				return nil, fmt.Errorf("parsing signature algorithm flag: %w", err)
+			}
+			algorithms = append(algorithms, algorithm)
+		}
+	}
+	algorithmsStr := make([]string, len(algorithms))
+	var err error
+	for i, a := range algorithms {
+		algorithmsStr[i], err = signature.FormatSignatureAlgorithmFlag(a)
+		if err != nil {
+			return nil, fmt.Errorf("formatting signature algorithm flag: %w", err)
+		}
+	}
+	algorithmRegistry, err := signature.NewAlgorithmRegistryConfig(algorithms)
+	if err != nil {
+		return nil, fmt.Errorf("getting algorithm registry: %w", err)
+	}
+	return algorithmRegistry, nil
+}
+
+// CheckEntryAlgorithms checks that the combination public key and message
+// digest algorithm are allowed given an algorithm registry.
+func CheckEntryAlgorithms(keyObj *x509.PublicKey, alg crypto.Hash, algorithmRegistry *signature.AlgorithmRegistryConfig) (bool, error) {
+	publicKey := keyObj.CryptoPubKey()
+	// Check if all the verifiers public keys (together with the
+	// artifactHashValue) are allowed according to the policy
+	isPermitted, err := algorithmRegistry.IsAlgorithmPermitted(publicKey, alg)
+	if err != nil {
+		return false, fmt.Errorf("checking if algorithm is permitted: %w", err)
+	}
+	if !isPermitted {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/algorithmregistry/algorithmregistry_test.go
+++ b/pkg/algorithmregistry/algorithmregistry_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package algorithmregistry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlgorithmRegistry(t *testing.T) {
+	tests := []struct {
+		name             string
+		algorithmOptions []string
+		wantErr          bool
+	}{
+		{
+			name:             "defaults",
+			algorithmOptions: nil,
+		},
+		{
+			name: "valid algorithms",
+			algorithmOptions: []string{
+				"ecdsa-sha2-384-nistp384",
+				"ecdsa-sha2-512-nistp521",
+				"ed25519",
+				"rsa-sign-pkcs1-3072-sha256",
+				"rsa-sign-pkcs1-4096-sha256",
+			},
+		},
+		{
+			name: "invalid algorithms",
+			algorithmOptions: []string{
+				"foo",
+				"bar",
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := AlgorithmRegistry(test.algorithmOptions)
+			if test.wantErr {
+				assert.Error(t, gotErr)
+				return
+			}
+			assert.NoError(t, gotErr)
+			assert.NotNil(t, got)
+		})
+	}
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	rekor_pb "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor-tiles/pkg/algorithmregistry"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
 	"github.com/stretchr/testify/assert"
 	ttessera "github.com/transparency-dev/trillian-tessera"
@@ -32,17 +33,23 @@ import (
 
 func TestNewServer(t *testing.T) {
 	storage := &mockStorage{}
-	server := NewServer(storage, false)
-	expectServer := &Server{storage: &mockStorage{}}
-	assert.Equal(t, expectServer, server)
+	algReg, err := algorithmregistry.AlgorithmRegistry([]string{"ecdsa-sha2-256-nistp256"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(storage, false, algReg)
+	assert.NoError(t, err)
+	assert.NotNil(t, server.storage)
+	assert.NotNil(t, server.algorithmRegistry)
 }
 
 func TestCreateEntry(t *testing.T) {
 	tests := []struct {
-		name        string
-		req         *pb.CreateEntryRequest
-		addFn       func() (*rekor_pb.TransparencyLogEntry, error)
-		expectError error
+		name                    string
+		req                     *pb.CreateEntryRequest
+		addFn                   func() (*rekor_pb.TransparencyLogEntry, error)
+		clientSigningAlgorithms []string
+		expectError             error
 	}{
 		{
 			name: "valid hashedrekord",
@@ -67,7 +74,8 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeLw7gX40qy1z7JUhGMAaaDITbV7p
 					},
 				},
 			},
-			addFn: func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			clientSigningAlgorithms: []string{"ecdsa-sha2-256-nistp256"},
 		},
 		{
 			name: "valid dsse",
@@ -100,7 +108,8 @@ qSTHiQhkA4/0ZAsJtmzn/v4HdeZKTCQcsHq5IwM/LtbmEdv9ChO9M3cg9g==
 					},
 				},
 			},
-			addFn: func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			clientSigningAlgorithms: []string{"ecdsa-sha2-256-nistp256"},
 		},
 		{
 			name: "invalid hashedrekord",
@@ -109,8 +118,9 @@ qSTHiQhkA4/0ZAsJtmzn/v4HdeZKTCQcsHq5IwM/LtbmEdv9ChO9M3cg9g==
 					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{},
 				},
 			},
-			addFn:       func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
-			expectError: fmt.Errorf("invalid hashedrekord request"),
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			clientSigningAlgorithms: []string{"ecdsa-sha2-256-nistp256"},
+			expectError:             fmt.Errorf("invalid hashedrekord request"),
 		},
 		{
 			name: "invalid dsse",
@@ -119,8 +129,9 @@ qSTHiQhkA4/0ZAsJtmzn/v4HdeZKTCQcsHq5IwM/LtbmEdv9ChO9M3cg9g==
 					DsseRequestV0_0_2: &pb.DSSERequestV0_0_2{},
 				},
 			},
-			addFn:       func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
-			expectError: fmt.Errorf("invalid dsse request"),
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			clientSigningAlgorithms: []string{"ecdsa-sha2-256-nistp256"},
+			expectError:             fmt.Errorf("invalid dsse request"),
 		},
 		{
 			name: "failed integration",
@@ -145,14 +156,45 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeLw7gX40qy1z7JUhGMAaaDITbV7p
 					},
 				},
 			},
-			addFn:       func() (*rekor_pb.TransparencyLogEntry, error) { return nil, fmt.Errorf("timed out") },
-			expectError: fmt.Errorf("failed to integrate entry"),
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return nil, fmt.Errorf("timed out") },
+			clientSigningAlgorithms: []string{"ecdsa-sha2-256-nistp256"},
+			expectError:             fmt.Errorf("failed to integrate entry"),
+		},
+		{
+			name: "hashedrekord signed with disallowed algorithm",
+			req: &pb.CreateEntryRequest{
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
+					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{
+						Signature: &pb.Signature{
+							Content: b64DecodeOrDie(t, "MEYCIQC59oLS3MsCqm0xCxPOy+8FdQK4RYCZE036s3q1ECfcagIhAJ4ATXlCSdFrklKAS8No0PsAE9uLi37TCbIfRXASJTTb"),
+							Verifier: &pb.Verifier{
+								Verifier: &pb.Verifier_PublicKey{
+									PublicKey: &pb.PublicKey{
+										RawBytes: []byte(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeLw7gX40qy1z7JUhGMAaaDITbV7p
+2D+C5G9xPEsy/PVAo9H0mgS4NYzpGirkXxBht+IvvL19WR1X9ANXha5ldQ==
+-----END PUBLIC KEY-----`),
+									},
+								},
+							},
+						},
+						Digest: hexDecodeOrDie(t, "5b3513f580c8397212ff2c8f459c199efc0c90e4354a5f3533adf0a3fff3a530"),
+					},
+				},
+			},
+			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
+			clientSigningAlgorithms: []string{"rsa-sign-pkcs1-4096-sha256"},
+			expectError:             fmt.Errorf("invalid hashedrekord request"),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			storage := &mockStorage{addFn: test.addFn}
-			server := NewServer(storage, false)
+			algReg, err := algorithmregistry.AlgorithmRegistry(test.clientSigningAlgorithms)
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := NewServer(storage, false, algReg)
 			gotTle, gotErr := server.CreateEntry(context.Background(), test.req)
 			if test.expectError == nil {
 				assert.NoError(t, gotErr)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Port over the configurable hash algorithms and key validation from
sigstore/rekor PR 1974. This both introduces a flag to restrict the
allowed signing algorithms for entries being submitted, as well as
validation to ensure the key used is within established constrictions
for the specified algorithm.

Much of this was borrowed from Rekor v1 with some modifications to
account for the different structure in rekor-tiles. Testing was done
here as unit tests rather than porting the script for the integration
tests from that PR.

Fixes https://github.com/sigstore/rekor-tiles/issues/100

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
