### PR TITLE
build: Add vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "e2e",
+}


### PR DESCRIPTION
Without this the language server can't handle tests/e2e_tests.go from #128

(if everyone else is some kind of emacs wizard I can keep this to myself too)