### PR TITLE
Shutdown Tessera gracefully on SIGTERM/SIGINT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rekorImagerefs
 /rekor-server
 .idea
 tools/bin/
+.vscode/

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -83,7 +83,7 @@ var serveCmd = &cobra.Command{
 			slog.Error(fmt.Sprintf("failed to configure antispam append options: %v", err))
 			os.Exit(1)
 		}
-		tesseraStorage, err := tessera.NewStorage(ctx, viper.GetString("hostname"), tesseraDriver, appendOptions)
+		tesseraStorage, shutdownFn, err := tessera.NewStorage(ctx, viper.GetString("hostname"), tesseraDriver, appendOptions)
 		if err != nil {
 			slog.Error(fmt.Sprintf("failed to initialize tessera storage: %v", err.Error()))
 			os.Exit(1)
@@ -99,6 +99,7 @@ var serveCmd = &cobra.Command{
 				server.WithGRPCPort(viper.GetInt("grpc-port")),
 				server.WithGRPCHost(viper.GetString("grpc-address"))),
 			server.NewServer(tesseraStorage),
+			shutdownFn,
 		)
 	},
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,4 @@
 coverage:
   status:
     patch: off
+    project: off

--- a/pkg/server/grpc_test.go
+++ b/pkg/server/grpc_test.go
@@ -31,6 +31,7 @@ func TestServe_grpcSmoke(t *testing.T) {
 	// slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
 	server := MockServer{}
 	server.Start(t)
+	defer server.Stop(t)
 
 	// check if we can hit grpc endpoints
 	conn, err := grpc.NewClient(
@@ -41,8 +42,6 @@ func TestServe_grpcSmoke(t *testing.T) {
 	}
 	client := pb.NewRekorClient(conn)
 	defer conn.Close()
-
-	defer server.Stop(t)
 
 	checkGRPCCreateEntry(t, client)
 	body, err := client.GetCheckpoint(context.Background(), &emptypb.Empty{})

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -45,7 +45,9 @@ func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s rekorServer, t
 
 	wg.Wait()
 
+	slog.Info("shutting down Tessera sequencer")
 	if err := tesseraShutdownFn(ctx); err != nil {
 		slog.Error("error shutting down Tessera", "error", err)
 	}
+	slog.Info("stopped Tessera sequencer")
 }

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Serve starts the grpc server and its http proxy.
-func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s rekorServer) {
+func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s rekorServer, tesseraShutdownFn func(context.Context) error) {
 	var wg sync.WaitGroup
 
 	if hc.port == 0 || gc.port == 0 {
@@ -44,4 +44,8 @@ func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s rekorServer) {
 	httpMetrics.start(&wg)
 
 	wg.Wait()
+
+	if err := tesseraShutdownFn(ctx); err != nil {
+		slog.Error("error shutting down Tessera", "error", err)
+	}
 }

--- a/pkg/server/serve_test.go
+++ b/pkg/server/serve_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestServe(t *testing.T) {
+	wg := sync.WaitGroup{}
+	var pid atomic.Uint64
+	shutdownFn := func(context.Context) error {
+		wg.Done()
+		return nil
+	}
+	go func() {
+		pid.Store(uint64(syscall.Getpid())) // Process IDs are positive ints
+		Serve(context.Background(), NewHTTPConfig(), NewGRPCConfig(), nil, shutdownFn)
+		wg.Done()
+	}()
+	// One for Serve returning, one for shutdown function being invoked
+	wg.Add(2)
+
+	i := 0
+	for {
+		if i == 5 {
+			t.Fatalf("could not get process ID in 5 seconds")
+		}
+		if pid.Load() != 0 {
+			break
+		}
+		i++
+		time.Sleep(1 * time.Second)
+	}
+
+	// Shutdown server gracefully to test that Serve shuts down gRPC and HTTP servers and Tessera connection
+	if err := syscall.Kill(int(pid.Load()), syscall.SIGTERM); err != nil {
+		t.Fatalf("Could not kill server")
+	}
+	wg.Wait()
+}

--- a/pkg/server/service_mock.go
+++ b/pkg/server/service_mock.go
@@ -41,11 +41,12 @@ func (ms *MockServer) Start(_ *testing.T) {
 	ms.gc = NewGRPCConfig()
 	ms.hc = NewHTTPConfig()
 	s := &mockRekorServer{}
+	shutdownFn := func(context.Context) error { return nil }
 
 	// Start the server
 	ms.wg = &sync.WaitGroup{}
 	go func() {
-		Serve(context.Background(), ms.hc, ms.gc, s)
+		Serve(context.Background(), ms.hc, ms.gc, s, shutdownFn)
 		ms.wg.Done()
 	}()
 	ms.wg.Add(1)

--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"time"
 
 	rekor_pb "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -111,6 +112,7 @@ func NewStorage(ctx context.Context, origin string, driver tessera.Driver, appen
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting tessera appender: %w", err)
 	}
+	slog.Info("starting Tessera sequencer")
 	awaiter := tessera.NewIntegrationAwaiter(ctx, reader.ReadCheckpoint, 1*time.Second)
 	return &storage{
 		origin:     origin,


### PR DESCRIPTION
Fixes #138

When SIGTERM/SIGINT is sent to the process, which occurs when Kubernetes is shutting down pods, the server gracefully shuts down the gRPC and HTTP servers. Tessera also provides a shutdown function which will wait until a checkpoint has been published that covers all sequenced entries.

This change plumbs this shutdown function through to call it when the server is shutting down.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
