### PR TITLE
Fix metrics test failure when run by itself

### DIFF
--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -29,12 +29,18 @@ func TestServe_httpMetricsSmoke(t *testing.T) {
 	server.Start(t)
 	defer server.Stop(t)
 
+	// Call an endpoint to create HTTP latency and request metrics
+	cpEndpoint := fmt.Sprintf("http://%s:%v/checkpoint", server.hc.host, server.hc.port)
+	if _, err := http.Get(cpEndpoint); err != nil {
+		t.Fatalf("fetching checkpoint from %s: %v", cpEndpoint, err)
+	}
+
 	// Check if we can hit the metrics endpoint
 	metricsURL := fmt.Sprintf("http://%s", server.hc.HTTPMetricsTarget())
 
 	resp, err := http.Get(metricsURL)
 	if err != nil {
-		t.Fatalf(metricsURL, err)
+		t.Fatalf("fetching metrics from %s, %v", metricsURL, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Fixes #162

This failure occurs because the HTTP latency and request metrics seem to be created only when a request has occurred.

When running all tests with go test ./..., no failure occurs, which is why CI didn't catch this. I believe this succeeded because another test triggered an HTTP request and however Prometheus is creating and scraping metrics created shared state between tests.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
