### PR TITLE
Delete remaining gRPC headers from HTTP response

### DIFF
--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -121,6 +122,13 @@ func checkHTTPPostWithClient(t *testing.T, baseURL string, client *http.Client) 
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
+
+	for header := range resp.Header {
+		if strings.HasPrefix(header, "Grpc-") {
+			t.Errorf("found gRPC header in HTTP response: %s", header)
+		}
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
 		return
@@ -144,6 +152,12 @@ func checkHTTPGetWithClient(t *testing.T, url, expectedBody string, client *http
 		t.Fatalf("%s: %v", url, err)
 	}
 	defer resp.Body.Close()
+
+	for header := range resp.Header {
+		if strings.HasPrefix(header, "Grpc-") {
+			t.Errorf("found gRPC header in HTTP response: %s", header)
+		}
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("%s: got %d want %d", url, resp.StatusCode, http.StatusOK)


### PR DESCRIPTION
The Grpc-Metadata-Content-Type header was still present in the HTTP response, this removes it.

Fixes #97 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
