### PR TITLE
Link TODOs to issues, ping healthz during mock server startup

### DIFF
--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -82,8 +82,7 @@ var _initMetricsFunc = sync.OnceValue[*metrics](func() *metrics {
 		Help: "API Request size on HTTP calls",
 	}, []string{"code", "method"})
 
-	// TODO(appu): add metrics from rekor v1 (anything but Counter appears to need to be a pointer)
-	// https://github.com/sigstore/rekor-tiles/issues/123
+	// TODO(#123): add metrics from rekor v1 (anything but Counter appears to need to be a pointer)
 
 	_ = f.NewGaugeFunc(
 		prometheus.GaugeOpts{
@@ -112,8 +111,6 @@ func newHTTPMetrics(_ context.Context, config *HTTPConfig) *httpMetrics {
 	mux.Handle("/", promhttp.HandlerFor(getMetrics().reg, promhttp.HandlerOpts{
 		Timeout: config.timeout,
 	}))
-
-	// TODO: configure https connection preferences (time-out, max size, etc)
 
 	endpoint := config.HTTPMetricsTarget()
 	return &httpMetrics{

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -143,6 +143,5 @@ func (s *Server) GetCheckpoint(context.Context, *emptypb.Empty) (*httpbody.HttpB
 // Check implements the Healthcheck protocol to report the health of the service.
 // See https://grpc-ecosystem.github.io/grpc-gateway/docs/operations/health_check/.
 func (s Server) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	// TODO: make this do more comprehensive healthchecking.
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }

--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -182,7 +182,7 @@ func (s *storage) buildProof(ctx context.Context, idx *SafeInt64, signedCheckpoi
 	if err != nil {
 		return nil, fmt.Errorf("invalid tree size: %d", checkpoint.Size)
 	}
-	// TODO(cmurphy): add metrics to detect when this inclusion proof ever fails as well as the overhead time for running this check.
+	// TODO(#202): add metrics to detect when this inclusion proof ever fails as well as the overhead time for running this check.
 	if err := proof.VerifyInclusion(rfc6962.DefaultHasher, idx.U(), safeCheckpointSize.U(), leafHash, inclusionProof, checkpoint.Hash); err != nil {
 		return nil, fmt.Errorf("failed to verify entry inclusion: %w", err)
 	}

--- a/pkg/types/dsse/dsse.go
+++ b/pkg/types/dsse/dsse.go
@@ -83,7 +83,7 @@ func ToLogEntry(ds *pb.DSSERequestV0_0_2, algorithmRegistry *signature.Algorithm
 
 	return &pb.DSSELogEntryV0_0_2{
 		PayloadHash: &v1.HashOutput{
-			// TODO: Change hardocded algorithm
+			// TODO(#195): Change hardocded algorithm
 			Algorithm: v1.HashAlgorithm_SHA2_256,
 			Digest:    payloadHash[:],
 		},

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -84,7 +84,7 @@ func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.A
 
 	return &pb.HashedRekordLogEntryV0_0_2{
 		Signature: hr.Signature,
-		// TODO: Remove hardcoded algorithm
+		// TODO(#195): Remove hardcoded algorithm
 		Data: &v1.HashOutput{Digest: hr.Digest, Algorithm: v1.HashAlgorithm_SHA2_256},
 	}, nil
 }

--- a/pkg/types/validator/validator.go
+++ b/pkg/types/validator/validator.go
@@ -21,7 +21,6 @@ import (
 )
 
 func Validate(v *pb.Verifier) error {
-	// TODO(cmurphy): hash/public key compatibility check (https://github.com/sigstore/rekor-tiles/issues/100)
 	publicKey := v.GetPublicKey()
 	x509Cert := v.GetX509Certificate()
 	if publicKey == nil && x509Cert == nil {

--- a/protoc-builder/Dockerfile
+++ b/protoc-builder/Dockerfile
@@ -36,7 +36,7 @@ RUN chown myuser /protobuf /googleapis /protobuf-specs
 USER myuser
 
 # Download specific release of protoc
-# TODO: add dependabot-like feature to check for release updates
+# TODO(#66): add dependabot-like feature to check for release updates
 ARG PROTOC_VERSION
 ARG PROTOC_VERSION_TAG
 ARG PROTOC_CHECKSUM
@@ -53,7 +53,8 @@ RUN git clone --filter=blob:none --no-checkout --depth=1 https://github.com/goog
     git checkout ${GOOGLEAPIS_COMMIT} && \
     rm -rf .git
 
-# fetch HEAD of protobuf-specs (TODO: adjust this to latest release like googleapis)
+# fetch HEAD of protobuf-specs
+# TODO(#66): adjust this to latest release like googleapis
 ARG PROTOBUF_SPECS_COMMIT
 RUN git clone --filter=blob:none --no-checkout --depth=1 https://github.com/sigstore/protobuf-specs.git /protobuf-specs && \
     cd /protobuf-specs && \

--- a/protoc-builder/Makefile
+++ b/protoc-builder/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: replace this whole build with https://github.com/sigstore/protobuf-specs/issues/542
+# TODO(#66): replace this whole build with https://github.com/sigstore/protobuf-specs/issues/542
 
 PROTOC_REKOR_IMAGE = protoc-rekor
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -171,7 +171,7 @@ func TestReadWrite(t *testing.T) {
 	assert.Contains(t, string(entryBundle), expectedB64PayloadHash)
 
 	// Add a second identical entries immediately to check for deduplication
-	// TODO(cmurphy): add more advanced deduplication checking when the Spanner emulator supports the "batch write" operation
+	// TODO(#158): add more advanced deduplication checking when the Spanner emulator supports the "batch write" operation
 	// (https://cloud.google.com/spanner/docs/batch-write) (https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/172).
 	oldIndex := tle.LogIndex
 	_, err = writer.Add(ctx, dr)


### PR DESCRIPTION
All TODOs now have an issue linked to make sure they're followed up on. This also resolves one TODO to use the healthcheck endpoint instead of just waiting a second.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
