### PR TITLE
Measure request payload sizes

### DIFF
--- a/pkg/server/grpcstats.go
+++ b/pkg/server/grpcstats.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/stats"
+)
+
+// GrpcStatsHandler consumes grpc stats and converts them to metrics
+type GrpcStatsHandler struct{}
+
+func (st *GrpcStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	// this is a no-op we don't care about connections for now
+	return ctx
+}
+
+func (st *GrpcStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
+	// this is a no-op we don't care about connections for now
+}
+
+type rpcStatCtxKey struct{}
+
+func (st *GrpcStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	// add the rpc info to the context so we can access the method name later
+	return context.WithValue(ctx, rpcStatCtxKey{}, info)
+}
+
+// HandleRPC processes the RPC stats. Note: All stat fields are read-only.
+func (st *GrpcStatsHandler) HandleRPC(ctx context.Context, stat stats.RPCStats) {
+	info, ok := ctx.Value(rpcStatCtxKey{}).(*stats.RPCTagInfo)
+	if !ok {
+		return
+	}
+	service, method := splitFullMethodName(info.FullMethodName)
+	switch t := stat.(type) {
+	case *stats.InPayload:
+		size := t.WireLength
+		getMetrics().grpcRequestSize.WithLabelValues(service, method, "payload").Observe(float64(size))
+	default:
+		// do nothing
+	}
+}
+
+func NewGrpcStatsHandler() *GrpcStatsHandler {
+	return &GrpcStatsHandler{}
+}
+
+// splitFullMethodName returns the service and method name of the RPC.
+func splitFullMethodName(fullMethod string) (string, string) {
+	fullMethod = strings.TrimPrefix(fullMethod, "/") // remove leading slash
+	if i := strings.Index(fullMethod, "/"); i >= 0 {
+		return fullMethod[:i], fullMethod[i+1:]
+	}
+	return "unknown", "unknown"
+}

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -103,7 +103,7 @@ func newHTTPProxy(ctx context.Context, config *HTTPConfig, grpcServer *grpcServe
 	handler := promhttp.InstrumentMetricHandler(metrics.reg, mux)
 	handler = promhttp.InstrumentHandlerDuration(metrics.httpLatency, handler)
 	handler = promhttp.InstrumentHandlerCounter(metrics.httpRequestsCount, handler)
-	handler = promhttp.InstrumentHandlerRequestSize(metrics.requestSize, handler)
+	handler = promhttp.InstrumentHandlerRequestSize(metrics.httpRequestSize, handler)
 	handler = http.MaxBytesHandler(handler, int64(config.maxRequestBodySize))
 
 	server := &http.Server{

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -29,12 +29,6 @@ func TestServe_httpMetricsSmoke(t *testing.T) {
 	server.Start(t)
 	defer server.Stop(t)
 
-	// Call an endpoint to create HTTP latency and request metrics
-	cpEndpoint := fmt.Sprintf("http://%s:%v/checkpoint", server.hc.host, server.hc.port)
-	if _, err := http.Get(cpEndpoint); err != nil {
-		t.Fatalf("fetching checkpoint from %s: %v", cpEndpoint, err)
-	}
-
 	// Check if we can hit the metrics endpoint
 	metricsURL := fmt.Sprintf("http://%s", server.hc.HTTPMetricsTarget())
 
@@ -54,13 +48,18 @@ func TestServe_httpMetricsSmoke(t *testing.T) {
 	}
 
 	b := string(body)
+
+	// we ping healthz in our MockServer that will initialize some http stats for us. On a raw
+	// server with no requests ever recorded, rekor_http_* statistics may be uninitialized
 	expectedMetrics := []string{
 		"rekor_new_hashedrekord_entries",
 		"rekor_new_dsse_entries",
 		"build_info",
 		"rekor_http_api_latency",
 		"rekor_http_requests_total",
+		"rekor_http_api_request_size",
 		"grpc_req_panics_recovered_total",
+		"grpc_api_request_size",
 		"grpc_server_started_total",    // should imply we have the default set of grpc server metrics
 		"grpc_server_handling_seconds", // should imply we have the default set of latency stats on grpc servers
 		"promhttp_metric_handler",      // should imply we have the default set of promhttp metrics


### PR DESCRIPTION
Uses grpc stats to get measurement information on payload sizes

#### Summary
Interceptors don't provide wiresize of payloads. StatsHandler appears to be the right place to get this info, so we grab it from there.

#### Release Note


#### Documentation

