### PR TITLE
Change N to be an encoded index for read APIs

### DIFF
--- a/api/proto/rekor_service.proto
+++ b/api/proto/rekor_service.proto
@@ -35,29 +35,18 @@ service Rekor {
             body: "*"
         };
     }
+
     // Get a tile from the log
     rpc GetTile (TileRequest) returns (google.api.HttpBody) {
         option (google.api.http) = {
-            get: "/api/v2/tile/{L}/{N}"
-        };
-    }
-    // Get a partial tile from the log
-    rpc GetPartialTile (PartialTileRequest) returns (google.api.HttpBody) {
-        option (google.api.http) = {
-            get: "/api/v2/tile/{L}/{N}/{W}"
+            get: "/api/v2/tile/{L}/{N=**}"
         };
     }
 
     // Get an entry bundle from the log
     rpc GetEntryBundle (EntryBundleRequest) returns (google.api.HttpBody) {
         option (google.api.http) = {
-            get: "/api/v2/tile/entries/{N}"
-        };
-    }
-    // Get a partial entry bundle from the log
-    rpc GetPartialEntryBundle (PartialEntryBundleRequest) returns (google.api.HttpBody) {
-        option (google.api.http) = {
-            get: "/api/v2/tile/entries/{N}/{W}"
+            get: "/api/v2/tile/entries/{N=**}"
         };
     }
 
@@ -83,26 +72,18 @@ message CreateEntryRequest {
     }
 }
 
-// a request for a full tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
+// Request for a full or partial tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
 message TileRequest {
-    int32 L = 1;
-    int32 N = 2;
+    uint32 L = 1;
+    // N must be either an index encoded as zero-padded 3-digit path elements, e.g. "x123/x456/789",
+    // and may end with ".p/<W>", where "<W>" is a uint8
+    string N = 2;
 }
 
-// a request for a partial tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
-message PartialTileRequest {
-    int32 L = 1;
-    string N = 2; // must match <int32>.p
-    int32 W = 3;
-}
-
-// a request for an entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
+// Request for a full or partial entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
 message EntryBundleRequest {
-    int32 N = 1;
+    // N must be either an index encoded as zero-padded 3-digit path elements, e.g. "x123/x456/789",
+    // and may end with ".p/<W>", where "<W>" is a uint8
+    string N = 1;
 }
 
-// a request for a partial entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
-message PartialEntryBundleRequest {
-    string N = 1; // must match <int32>.p
-    int32 W = 2;
-}

--- a/docs/openapi/rekor_service.swagger.json
+++ b/docs/openapi/rekor_service.swagger.json
@@ -93,49 +93,11 @@
         "parameters": [
           {
             "name": "N",
+            "description": "N must be either an index encoded as zero-padded 3-digit path elements, e.g. \"x123/x456/789\",\nand may end with \".p/\u003cW\u003e\", where \"\u003cW\u003e\" is a uint8",
             "in": "path",
             "required": true,
-            "type": "integer",
-            "format": "int32"
-          }
-        ],
-        "tags": [
-          "Rekor"
-        ]
-      }
-    },
-    "/api/v2/tile/entries/{N}/{W}": {
-      "get": {
-        "summary": "Get a partial entry bundle from the log",
-        "operationId": "Rekor_GetPartialEntryBundle",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiHttpBody"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "N",
-            "description": "must match \u003cint32\u003e.p",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "W",
-            "in": "path",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "pattern": ".+"
           }
         ],
         "tags": [
@@ -167,60 +129,15 @@
             "in": "path",
             "required": true,
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           {
             "name": "N",
+            "description": "N must be either an index encoded as zero-padded 3-digit path elements, e.g. \"x123/x456/789\",\nand may end with \".p/\u003cW\u003e\", where \"\u003cW\u003e\" is a uint8",
             "in": "path",
             "required": true,
-            "type": "integer",
-            "format": "int32"
-          }
-        ],
-        "tags": [
-          "Rekor"
-        ]
-      }
-    },
-    "/api/v2/tile/{L}/{N}/{W}": {
-      "get": {
-        "summary": "Get a partial tile from the log",
-        "operationId": "Rekor_GetPartialTile",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiHttpBody"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "L",
-            "in": "path",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "N",
-            "description": "must match \u003cint32\u003e.p",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "W",
-            "in": "path",
-            "required": true,
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "pattern": ".+"
           }
         ],
         "tags": [

--- a/pkg/generated/protobuf/rekor_service.pb.go
+++ b/pkg/generated/protobuf/rekor_service.pb.go
@@ -122,11 +122,13 @@ func (*CreateEntryRequest_HashedRekordRequestV0_0_2) isCreateEntryRequest_Spec()
 
 func (*CreateEntryRequest_DsseRequestV0_0_2) isCreateEntryRequest_Spec() {}
 
-// a request for a full tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
+// Request for a full or partial tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
 type TileRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	L             int32                  `protobuf:"varint,1,opt,name=L,proto3" json:"L,omitempty"`
-	N             int32                  `protobuf:"varint,2,opt,name=N,proto3" json:"N,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	L     uint32                 `protobuf:"varint,1,opt,name=L,proto3" json:"L,omitempty"`
+	// N must be either an index encoded as zero-padded 3-digit path elements, e.g. "x123/x456/789",
+	// and may end with ".p/<W>", where "<W>" is a uint8
+	N             string `protobuf:"bytes,2,opt,name=N,proto3" json:"N,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -161,92 +163,33 @@ func (*TileRequest) Descriptor() ([]byte, []int) {
 	return file_rekor_service_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *TileRequest) GetL() int32 {
+func (x *TileRequest) GetL() uint32 {
 	if x != nil {
 		return x.L
 	}
 	return 0
 }
 
-func (x *TileRequest) GetN() int32 {
-	if x != nil {
-		return x.N
-	}
-	return 0
-}
-
-// a request for a partial tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
-type PartialTileRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	L             int32                  `protobuf:"varint,1,opt,name=L,proto3" json:"L,omitempty"`
-	N             string                 `protobuf:"bytes,2,opt,name=N,proto3" json:"N,omitempty"` // must match <int32>.p
-	W             int32                  `protobuf:"varint,3,opt,name=W,proto3" json:"W,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PartialTileRequest) Reset() {
-	*x = PartialTileRequest{}
-	mi := &file_rekor_service_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PartialTileRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PartialTileRequest) ProtoMessage() {}
-
-func (x *PartialTileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rekor_service_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PartialTileRequest.ProtoReflect.Descriptor instead.
-func (*PartialTileRequest) Descriptor() ([]byte, []int) {
-	return file_rekor_service_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *PartialTileRequest) GetL() int32 {
-	if x != nil {
-		return x.L
-	}
-	return 0
-}
-
-func (x *PartialTileRequest) GetN() string {
+func (x *TileRequest) GetN() string {
 	if x != nil {
 		return x.N
 	}
 	return ""
 }
 
-func (x *PartialTileRequest) GetW() int32 {
-	if x != nil {
-		return x.W
-	}
-	return 0
-}
-
-// a request for an entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
+// Request for a full or partial entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
 type EntryBundleRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	N             int32                  `protobuf:"varint,1,opt,name=N,proto3" json:"N,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// N must be either an index encoded as zero-padded 3-digit path elements, e.g. "x123/x456/789",
+	// and may end with ".p/<W>", where "<W>" is a uint8
+	N             string `protobuf:"bytes,1,opt,name=N,proto3" json:"N,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EntryBundleRequest) Reset() {
 	*x = EntryBundleRequest{}
-	mi := &file_rekor_service_proto_msgTypes[3]
+	mi := &file_rekor_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -258,7 +201,7 @@ func (x *EntryBundleRequest) String() string {
 func (*EntryBundleRequest) ProtoMessage() {}
 
 func (x *EntryBundleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rekor_service_proto_msgTypes[3]
+	mi := &file_rekor_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -271,67 +214,14 @@ func (x *EntryBundleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntryBundleRequest.ProtoReflect.Descriptor instead.
 func (*EntryBundleRequest) Descriptor() ([]byte, []int) {
-	return file_rekor_service_proto_rawDescGZIP(), []int{3}
+	return file_rekor_service_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *EntryBundleRequest) GetN() int32 {
-	if x != nil {
-		return x.N
-	}
-	return 0
-}
-
-// a request for a partial entry bundle (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#log-entries)
-type PartialEntryBundleRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	N             string                 `protobuf:"bytes,1,opt,name=N,proto3" json:"N,omitempty"` // must match <int32>.p
-	W             int32                  `protobuf:"varint,2,opt,name=W,proto3" json:"W,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PartialEntryBundleRequest) Reset() {
-	*x = PartialEntryBundleRequest{}
-	mi := &file_rekor_service_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PartialEntryBundleRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PartialEntryBundleRequest) ProtoMessage() {}
-
-func (x *PartialEntryBundleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rekor_service_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PartialEntryBundleRequest.ProtoReflect.Descriptor instead.
-func (*PartialEntryBundleRequest) Descriptor() ([]byte, []int) {
-	return file_rekor_service_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *PartialEntryBundleRequest) GetN() string {
+func (x *EntryBundleRequest) GetN() string {
 	if x != nil {
 		return x.N
 	}
 	return ""
-}
-
-func (x *PartialEntryBundleRequest) GetW() int32 {
-	if x != nil {
-		return x.W
-	}
-	return 0
 }
 
 var File_rekor_service_proto protoreflect.FileDescriptor
@@ -345,23 +235,14 @@ const file_rekor_service_proto_rawDesc = "" +
 	"\x13dsse_request_v0_0_2\x18\x02 \x01(\v2(.dev.sigstore.rekor.v2.DSSERequestV0_0_2B\x03\xe0A\x02H\x00R\x11dsseRequestV0_0_2B\x06\n" +
 	"\x04spec\")\n" +
 	"\vTileRequest\x12\f\n" +
-	"\x01L\x18\x01 \x01(\x05R\x01L\x12\f\n" +
-	"\x01N\x18\x02 \x01(\x05R\x01N\">\n" +
-	"\x12PartialTileRequest\x12\f\n" +
-	"\x01L\x18\x01 \x01(\x05R\x01L\x12\f\n" +
-	"\x01N\x18\x02 \x01(\tR\x01N\x12\f\n" +
-	"\x01W\x18\x03 \x01(\x05R\x01W\"\"\n" +
+	"\x01L\x18\x01 \x01(\rR\x01L\x12\f\n" +
+	"\x01N\x18\x02 \x01(\tR\x01N\"\"\n" +
 	"\x12EntryBundleRequest\x12\f\n" +
-	"\x01N\x18\x01 \x01(\x05R\x01N\"7\n" +
-	"\x19PartialEntryBundleRequest\x12\f\n" +
-	"\x01N\x18\x01 \x01(\tR\x01N\x12\f\n" +
-	"\x01W\x18\x02 \x01(\x05R\x01W2\xbf\x05\n" +
+	"\x01N\x18\x01 \x01(\tR\x01N2\xc8\x03\n" +
 	"\x05Rekor\x12\x85\x01\n" +
-	"\vCreateEntry\x12).dev.sigstore.rekor.v2.CreateEntryRequest\x1a+.dev.sigstore.rekor.v1.TransparencyLogEntry\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/api/v2/log/entries\x12a\n" +
-	"\aGetTile\x12\".dev.sigstore.rekor.v2.TileRequest\x1a\x14.google.api.HttpBody\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/api/v2/tile/{L}/{N}\x12s\n" +
-	"\x0eGetPartialTile\x12).dev.sigstore.rekor.v2.PartialTileRequest\x1a\x14.google.api.HttpBody\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/api/v2/tile/{L}/{N}/{W}\x12s\n" +
-	"\x0eGetEntryBundle\x12).dev.sigstore.rekor.v2.EntryBundleRequest\x1a\x14.google.api.HttpBody\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/api/v2/tile/entries/{N}\x12\x85\x01\n" +
-	"\x15GetPartialEntryBundle\x120.dev.sigstore.rekor.v2.PartialEntryBundleRequest\x1a\x14.google.api.HttpBody\"$\x82\xd3\xe4\x93\x02\x1e\x12\x1c/api/v2/tile/entries/{N}/{W}\x12Y\n" +
+	"\vCreateEntry\x12).dev.sigstore.rekor.v2.CreateEntryRequest\x1a+.dev.sigstore.rekor.v1.TransparencyLogEntry\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/api/v2/log/entries\x12d\n" +
+	"\aGetTile\x12\".dev.sigstore.rekor.v2.TileRequest\x1a\x14.google.api.HttpBody\"\x1f\x82\xd3\xe4\x93\x02\x19\x12\x17/api/v2/tile/{L}/{N=**}\x12v\n" +
+	"\x0eGetEntryBundle\x12).dev.sigstore.rekor.v2.EntryBundleRequest\x1a\x14.google.api.HttpBody\"#\x82\xd3\xe4\x93\x02\x1d\x12\x1b/api/v2/tile/entries/{N=**}\x12Y\n" +
 	"\rGetCheckpoint\x12\x16.google.protobuf.Empty\x1a\x14.google.api.HttpBody\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/api/v2/checkpointB8Z6github.com/sigstore/rekor-tiles/pkg/generated/protobufb\x06proto3"
 
 var (
@@ -376,36 +257,30 @@ func file_rekor_service_proto_rawDescGZIP() []byte {
 	return file_rekor_service_proto_rawDescData
 }
 
-var file_rekor_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_rekor_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_rekor_service_proto_goTypes = []any{
 	(*CreateEntryRequest)(nil),        // 0: dev.sigstore.rekor.v2.CreateEntryRequest
 	(*TileRequest)(nil),               // 1: dev.sigstore.rekor.v2.TileRequest
-	(*PartialTileRequest)(nil),        // 2: dev.sigstore.rekor.v2.PartialTileRequest
-	(*EntryBundleRequest)(nil),        // 3: dev.sigstore.rekor.v2.EntryBundleRequest
-	(*PartialEntryBundleRequest)(nil), // 4: dev.sigstore.rekor.v2.PartialEntryBundleRequest
-	(*HashedRekordRequestV0_0_2)(nil), // 5: dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
-	(*DSSERequestV0_0_2)(nil),         // 6: dev.sigstore.rekor.v2.DSSERequestV0_0_2
-	(*emptypb.Empty)(nil),             // 7: google.protobuf.Empty
-	(*v1.TransparencyLogEntry)(nil),   // 8: dev.sigstore.rekor.v1.TransparencyLogEntry
-	(*httpbody.HttpBody)(nil),         // 9: google.api.HttpBody
+	(*EntryBundleRequest)(nil),        // 2: dev.sigstore.rekor.v2.EntryBundleRequest
+	(*HashedRekordRequestV0_0_2)(nil), // 3: dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
+	(*DSSERequestV0_0_2)(nil),         // 4: dev.sigstore.rekor.v2.DSSERequestV0_0_2
+	(*emptypb.Empty)(nil),             // 5: google.protobuf.Empty
+	(*v1.TransparencyLogEntry)(nil),   // 6: dev.sigstore.rekor.v1.TransparencyLogEntry
+	(*httpbody.HttpBody)(nil),         // 7: google.api.HttpBody
 }
 var file_rekor_service_proto_depIdxs = []int32{
-	5, // 0: dev.sigstore.rekor.v2.CreateEntryRequest.hashed_rekord_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
-	6, // 1: dev.sigstore.rekor.v2.CreateEntryRequest.dsse_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.DSSERequestV0_0_2
+	3, // 0: dev.sigstore.rekor.v2.CreateEntryRequest.hashed_rekord_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
+	4, // 1: dev.sigstore.rekor.v2.CreateEntryRequest.dsse_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.DSSERequestV0_0_2
 	0, // 2: dev.sigstore.rekor.v2.Rekor.CreateEntry:input_type -> dev.sigstore.rekor.v2.CreateEntryRequest
 	1, // 3: dev.sigstore.rekor.v2.Rekor.GetTile:input_type -> dev.sigstore.rekor.v2.TileRequest
-	2, // 4: dev.sigstore.rekor.v2.Rekor.GetPartialTile:input_type -> dev.sigstore.rekor.v2.PartialTileRequest
-	3, // 5: dev.sigstore.rekor.v2.Rekor.GetEntryBundle:input_type -> dev.sigstore.rekor.v2.EntryBundleRequest
-	4, // 6: dev.sigstore.rekor.v2.Rekor.GetPartialEntryBundle:input_type -> dev.sigstore.rekor.v2.PartialEntryBundleRequest
-	7, // 7: dev.sigstore.rekor.v2.Rekor.GetCheckpoint:input_type -> google.protobuf.Empty
-	8, // 8: dev.sigstore.rekor.v2.Rekor.CreateEntry:output_type -> dev.sigstore.rekor.v1.TransparencyLogEntry
-	9, // 9: dev.sigstore.rekor.v2.Rekor.GetTile:output_type -> google.api.HttpBody
-	9, // 10: dev.sigstore.rekor.v2.Rekor.GetPartialTile:output_type -> google.api.HttpBody
-	9, // 11: dev.sigstore.rekor.v2.Rekor.GetEntryBundle:output_type -> google.api.HttpBody
-	9, // 12: dev.sigstore.rekor.v2.Rekor.GetPartialEntryBundle:output_type -> google.api.HttpBody
-	9, // 13: dev.sigstore.rekor.v2.Rekor.GetCheckpoint:output_type -> google.api.HttpBody
-	8, // [8:14] is the sub-list for method output_type
-	2, // [2:8] is the sub-list for method input_type
+	2, // 4: dev.sigstore.rekor.v2.Rekor.GetEntryBundle:input_type -> dev.sigstore.rekor.v2.EntryBundleRequest
+	5, // 5: dev.sigstore.rekor.v2.Rekor.GetCheckpoint:input_type -> google.protobuf.Empty
+	6, // 6: dev.sigstore.rekor.v2.Rekor.CreateEntry:output_type -> dev.sigstore.rekor.v1.TransparencyLogEntry
+	7, // 7: dev.sigstore.rekor.v2.Rekor.GetTile:output_type -> google.api.HttpBody
+	7, // 8: dev.sigstore.rekor.v2.Rekor.GetEntryBundle:output_type -> google.api.HttpBody
+	7, // 9: dev.sigstore.rekor.v2.Rekor.GetCheckpoint:output_type -> google.api.HttpBody
+	6, // [6:10] is the sub-list for method output_type
+	2, // [2:6] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -428,7 +303,7 @@ func file_rekor_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_rekor_service_proto_rawDesc), len(file_rekor_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/generated/protobuf/rekor_service.pb.gw.go
+++ b/pkg/generated/protobuf/rekor_service.pb.gw.go
@@ -71,7 +71,7 @@ func request_Rekor_GetTile_0(ctx context.Context, marshaler runtime.Marshaler, c
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "L")
 	}
-	protoReq.L, err = runtime.Int32(val)
+	protoReq.L, err = runtime.Uint32(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "L", err)
 	}
@@ -79,7 +79,7 @@ func request_Rekor_GetTile_0(ctx context.Context, marshaler runtime.Marshaler, c
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
 	}
-	protoReq.N, err = runtime.Int32(val)
+	protoReq.N, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
 	}
@@ -97,7 +97,7 @@ func local_request_Rekor_GetTile_0(ctx context.Context, marshaler runtime.Marsha
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "L")
 	}
-	protoReq.L, err = runtime.Int32(val)
+	protoReq.L, err = runtime.Uint32(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "L", err)
 	}
@@ -105,80 +105,11 @@ func local_request_Rekor_GetTile_0(ctx context.Context, marshaler runtime.Marsha
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
 	}
-	protoReq.N, err = runtime.Int32(val)
+	protoReq.N, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
 	}
 	msg, err := server.GetTile(ctx, &protoReq)
-	return msg, metadata, err
-}
-
-func request_Rekor_GetPartialTile_0(ctx context.Context, marshaler runtime.Marshaler, client RekorClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq PartialTileRequest
-		metadata runtime.ServerMetadata
-		err      error
-	)
-	io.Copy(io.Discard, req.Body)
-	val, ok := pathParams["L"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "L")
-	}
-	protoReq.L, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "L", err)
-	}
-	val, ok = pathParams["N"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
-	}
-	protoReq.N, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
-	}
-	val, ok = pathParams["W"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "W")
-	}
-	protoReq.W, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "W", err)
-	}
-	msg, err := client.GetPartialTile(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_Rekor_GetPartialTile_0(ctx context.Context, marshaler runtime.Marshaler, server RekorServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq PartialTileRequest
-		metadata runtime.ServerMetadata
-		err      error
-	)
-	val, ok := pathParams["L"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "L")
-	}
-	protoReq.L, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "L", err)
-	}
-	val, ok = pathParams["N"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
-	}
-	protoReq.N, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
-	}
-	val, ok = pathParams["W"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "W")
-	}
-	protoReq.W, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "W", err)
-	}
-	msg, err := server.GetPartialTile(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -193,7 +124,7 @@ func request_Rekor_GetEntryBundle_0(ctx context.Context, marshaler runtime.Marsh
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
 	}
-	protoReq.N, err = runtime.Int32(val)
+	protoReq.N, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
 	}
@@ -211,64 +142,11 @@ func local_request_Rekor_GetEntryBundle_0(ctx context.Context, marshaler runtime
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
 	}
-	protoReq.N, err = runtime.Int32(val)
+	protoReq.N, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
 	}
 	msg, err := server.GetEntryBundle(ctx, &protoReq)
-	return msg, metadata, err
-}
-
-func request_Rekor_GetPartialEntryBundle_0(ctx context.Context, marshaler runtime.Marshaler, client RekorClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq PartialEntryBundleRequest
-		metadata runtime.ServerMetadata
-		err      error
-	)
-	io.Copy(io.Discard, req.Body)
-	val, ok := pathParams["N"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
-	}
-	protoReq.N, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
-	}
-	val, ok = pathParams["W"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "W")
-	}
-	protoReq.W, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "W", err)
-	}
-	msg, err := client.GetPartialEntryBundle(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_Rekor_GetPartialEntryBundle_0(ctx context.Context, marshaler runtime.Marshaler, server RekorServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq PartialEntryBundleRequest
-		metadata runtime.ServerMetadata
-		err      error
-	)
-	val, ok := pathParams["N"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "N")
-	}
-	protoReq.N, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "N", err)
-	}
-	val, ok = pathParams["W"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "W")
-	}
-	protoReq.W, err = runtime.Int32(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "W", err)
-	}
-	msg, err := server.GetPartialEntryBundle(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -323,7 +201,7 @@ func RegisterRekorHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N=**}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -337,33 +215,13 @@ func RegisterRekorHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 		forward_Rekor_GetTile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_Rekor_GetPartialTile_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetPartialTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N}/{W}"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Rekor_GetPartialTile_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_Rekor_GetPartialTile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
 	mux.Handle(http.MethodGet, pattern_Rekor_GetEntryBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N=**}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -376,26 +234,6 @@ func RegisterRekorHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 			return
 		}
 		forward_Rekor_GetEntryBundle_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
-	mux.Handle(http.MethodGet, pattern_Rekor_GetPartialEntryBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetPartialEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N}/{W}"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Rekor_GetPartialEntryBundle_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_Rekor_GetPartialEntryBundle_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodGet, pattern_Rekor_GetCheckpoint_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -478,7 +316,7 @@ func RegisterRekorHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N=**}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -491,28 +329,11 @@ func RegisterRekorHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 		forward_Rekor_GetTile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_Rekor_GetPartialTile_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetPartialTile", runtime.WithHTTPPathPattern("/api/v2/tile/{L}/{N}/{W}"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Rekor_GetPartialTile_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_Rekor_GetPartialTile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
 	mux.Handle(http.MethodGet, pattern_Rekor_GetEntryBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N=**}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -524,23 +345,6 @@ func RegisterRekorHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 			return
 		}
 		forward_Rekor_GetEntryBundle_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
-	mux.Handle(http.MethodGet, pattern_Rekor_GetPartialEntryBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/dev.sigstore.rekor.v2.Rekor/GetPartialEntryBundle", runtime.WithHTTPPathPattern("/api/v2/tile/entries/{N}/{W}"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Rekor_GetPartialEntryBundle_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_Rekor_GetPartialEntryBundle_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodGet, pattern_Rekor_GetCheckpoint_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -563,19 +367,15 @@ func RegisterRekorHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 }
 
 var (
-	pattern_Rekor_CreateEntry_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v2", "log", "entries"}, ""))
-	pattern_Rekor_GetTile_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "v2", "tile", "L", "N"}, ""))
-	pattern_Rekor_GetPartialTile_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5}, []string{"api", "v2", "tile", "L", "N", "W"}, ""))
-	pattern_Rekor_GetEntryBundle_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "v2", "tile", "entries", "N"}, ""))
-	pattern_Rekor_GetPartialEntryBundle_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5}, []string{"api", "v2", "tile", "entries", "N", "W"}, ""))
-	pattern_Rekor_GetCheckpoint_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v2", "checkpoint"}, ""))
+	pattern_Rekor_CreateEntry_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v2", "log", "entries"}, ""))
+	pattern_Rekor_GetTile_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 3, 0, 4, 1, 5, 4}, []string{"api", "v2", "tile", "L", "N"}, ""))
+	pattern_Rekor_GetEntryBundle_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 3, 0, 4, 1, 5, 4}, []string{"api", "v2", "tile", "entries", "N"}, ""))
+	pattern_Rekor_GetCheckpoint_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v2", "checkpoint"}, ""))
 )
 
 var (
-	forward_Rekor_CreateEntry_0           = runtime.ForwardResponseMessage
-	forward_Rekor_GetTile_0               = runtime.ForwardResponseMessage
-	forward_Rekor_GetPartialTile_0        = runtime.ForwardResponseMessage
-	forward_Rekor_GetEntryBundle_0        = runtime.ForwardResponseMessage
-	forward_Rekor_GetPartialEntryBundle_0 = runtime.ForwardResponseMessage
-	forward_Rekor_GetCheckpoint_0         = runtime.ForwardResponseMessage
+	forward_Rekor_CreateEntry_0    = runtime.ForwardResponseMessage
+	forward_Rekor_GetTile_0        = runtime.ForwardResponseMessage
+	forward_Rekor_GetEntryBundle_0 = runtime.ForwardResponseMessage
+	forward_Rekor_GetCheckpoint_0  = runtime.ForwardResponseMessage
 )

--- a/pkg/generated/protobuf/rekor_service_grpc.pb.go
+++ b/pkg/generated/protobuf/rekor_service_grpc.pb.go
@@ -36,12 +36,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Rekor_CreateEntry_FullMethodName           = "/dev.sigstore.rekor.v2.Rekor/CreateEntry"
-	Rekor_GetTile_FullMethodName               = "/dev.sigstore.rekor.v2.Rekor/GetTile"
-	Rekor_GetPartialTile_FullMethodName        = "/dev.sigstore.rekor.v2.Rekor/GetPartialTile"
-	Rekor_GetEntryBundle_FullMethodName        = "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle"
-	Rekor_GetPartialEntryBundle_FullMethodName = "/dev.sigstore.rekor.v2.Rekor/GetPartialEntryBundle"
-	Rekor_GetCheckpoint_FullMethodName         = "/dev.sigstore.rekor.v2.Rekor/GetCheckpoint"
+	Rekor_CreateEntry_FullMethodName    = "/dev.sigstore.rekor.v2.Rekor/CreateEntry"
+	Rekor_GetTile_FullMethodName        = "/dev.sigstore.rekor.v2.Rekor/GetTile"
+	Rekor_GetEntryBundle_FullMethodName = "/dev.sigstore.rekor.v2.Rekor/GetEntryBundle"
+	Rekor_GetCheckpoint_FullMethodName  = "/dev.sigstore.rekor.v2.Rekor/GetCheckpoint"
 )
 
 // RekorClient is the client API for Rekor service.
@@ -55,12 +53,8 @@ type RekorClient interface {
 	CreateEntry(ctx context.Context, in *CreateEntryRequest, opts ...grpc.CallOption) (*v1.TransparencyLogEntry, error)
 	// Get a tile from the log
 	GetTile(ctx context.Context, in *TileRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error)
-	// Get a partial tile from the log
-	GetPartialTile(ctx context.Context, in *PartialTileRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error)
 	// Get an entry bundle from the log
 	GetEntryBundle(ctx context.Context, in *EntryBundleRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error)
-	// Get a partial entry bundle from the log
-	GetPartialEntryBundle(ctx context.Context, in *PartialEntryBundleRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error)
 	// Get a checkpoint from the log
 	GetCheckpoint(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*httpbody.HttpBody, error)
 }
@@ -93,30 +87,10 @@ func (c *rekorClient) GetTile(ctx context.Context, in *TileRequest, opts ...grpc
 	return out, nil
 }
 
-func (c *rekorClient) GetPartialTile(ctx context.Context, in *PartialTileRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(httpbody.HttpBody)
-	err := c.cc.Invoke(ctx, Rekor_GetPartialTile_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *rekorClient) GetEntryBundle(ctx context.Context, in *EntryBundleRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(httpbody.HttpBody)
 	err := c.cc.Invoke(ctx, Rekor_GetEntryBundle_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *rekorClient) GetPartialEntryBundle(ctx context.Context, in *PartialEntryBundleRequest, opts ...grpc.CallOption) (*httpbody.HttpBody, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(httpbody.HttpBody)
-	err := c.cc.Invoke(ctx, Rekor_GetPartialEntryBundle_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,12 +118,8 @@ type RekorServer interface {
 	CreateEntry(context.Context, *CreateEntryRequest) (*v1.TransparencyLogEntry, error)
 	// Get a tile from the log
 	GetTile(context.Context, *TileRequest) (*httpbody.HttpBody, error)
-	// Get a partial tile from the log
-	GetPartialTile(context.Context, *PartialTileRequest) (*httpbody.HttpBody, error)
 	// Get an entry bundle from the log
 	GetEntryBundle(context.Context, *EntryBundleRequest) (*httpbody.HttpBody, error)
-	// Get a partial entry bundle from the log
-	GetPartialEntryBundle(context.Context, *PartialEntryBundleRequest) (*httpbody.HttpBody, error)
 	// Get a checkpoint from the log
 	GetCheckpoint(context.Context, *emptypb.Empty) (*httpbody.HttpBody, error)
 	mustEmbedUnimplementedRekorServer()
@@ -168,14 +138,8 @@ func (UnimplementedRekorServer) CreateEntry(context.Context, *CreateEntryRequest
 func (UnimplementedRekorServer) GetTile(context.Context, *TileRequest) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTile not implemented")
 }
-func (UnimplementedRekorServer) GetPartialTile(context.Context, *PartialTileRequest) (*httpbody.HttpBody, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetPartialTile not implemented")
-}
 func (UnimplementedRekorServer) GetEntryBundle(context.Context, *EntryBundleRequest) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEntryBundle not implemented")
-}
-func (UnimplementedRekorServer) GetPartialEntryBundle(context.Context, *PartialEntryBundleRequest) (*httpbody.HttpBody, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetPartialEntryBundle not implemented")
 }
 func (UnimplementedRekorServer) GetCheckpoint(context.Context, *emptypb.Empty) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetCheckpoint not implemented")
@@ -237,24 +201,6 @@ func _Rekor_GetTile_Handler(srv interface{}, ctx context.Context, dec func(inter
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Rekor_GetPartialTile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PartialTileRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RekorServer).GetPartialTile(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: Rekor_GetPartialTile_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RekorServer).GetPartialTile(ctx, req.(*PartialTileRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _Rekor_GetEntryBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EntryBundleRequest)
 	if err := dec(in); err != nil {
@@ -269,24 +215,6 @@ func _Rekor_GetEntryBundle_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RekorServer).GetEntryBundle(ctx, req.(*EntryBundleRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _Rekor_GetPartialEntryBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PartialEntryBundleRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RekorServer).GetPartialEntryBundle(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: Rekor_GetPartialEntryBundle_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RekorServer).GetPartialEntryBundle(ctx, req.(*PartialEntryBundleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -325,16 +253,8 @@ var Rekor_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Rekor_GetTile_Handler,
 		},
 		{
-			MethodName: "GetPartialTile",
-			Handler:    _Rekor_GetPartialTile_Handler,
-		},
-		{
 			MethodName: "GetEntryBundle",
 			Handler:    _Rekor_GetEntryBundle_Handler,
-		},
-		{
-			MethodName: "GetPartialEntryBundle",
-			Handler:    _Rekor_GetPartialEntryBundle_Handler,
 		},
 		{
 			MethodName: "GetCheckpoint",

--- a/pkg/server/grpc_test.go
+++ b/pkg/server/grpc_test.go
@@ -110,23 +110,43 @@ func testEndpoints(t *testing.T, client pb.RekorClient) {
 	})
 
 	t.Run("get tile", func(t *testing.T) {
-		body, err := client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: 2})
-		checkGRPC(t, body, err, "test-tile:1,2")
+		body, err := client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: "002"})
+		checkGRPC(t, body, err, "test-tile:1,2,0")
+	})
+
+	t.Run("get tile with larger index", func(t *testing.T) {
+		body, err := client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: "x123/456"})
+		checkGRPC(t, body, err, "test-tile:1,123456,0")
 	})
 
 	t.Run("get partial tile", func(t *testing.T) {
-		body, err := client.GetPartialTile(context.Background(), &pb.PartialTileRequest{L: 1, N: "2.p", W: 3})
-		checkGRPC(t, body, err, "test-tile:1,2.p,3")
+		body, err := client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: "123.p/45"})
+		checkGRPC(t, body, err, "test-tile:1,123,45")
+	})
+
+	t.Run("get tile with larger index and partial", func(t *testing.T) {
+		body, err := client.GetTile(context.Background(), &pb.TileRequest{L: 1, N: "x123/456.p/7"})
+		checkGRPC(t, body, err, "test-tile:1,123456,7")
 	})
 
 	t.Run("get entry bundle", func(t *testing.T) {
-		body, err := client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: 1})
-		checkGRPC(t, body, err, "test-entries:1")
+		body, err := client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: "001"})
+		checkGRPC(t, body, err, "test-entries:1,0")
+	})
+
+	t.Run("get entry bundle with larger index", func(t *testing.T) {
+		body, err := client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: "x123/456"})
+		checkGRPC(t, body, err, "test-entries:123456,0")
 	})
 
 	t.Run("get partial entry bundle", func(t *testing.T) {
-		body, err := client.GetPartialEntryBundle(context.Background(), &pb.PartialEntryBundleRequest{N: "1.p", W: 2})
-		checkGRPC(t, body, err, "test-entries:1.p,2")
+		body, err := client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: "123.p/45"})
+		checkGRPC(t, body, err, "test-entries:123,45")
+	})
+
+	t.Run("get entry bundle with larger index and partial", func(t *testing.T) {
+		body, err := client.GetEntryBundle(context.Background(), &pb.EntryBundleRequest{N: "x123/456.p/7"})
+		checkGRPC(t, body, err, "test-entries:123456,7")
 	})
 }
 func TestLoadTLSCredentials(t *testing.T) {

--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -35,10 +35,12 @@ var endpointTests = []struct {
 	expectedBody string
 }{
 	{"/api/v2/checkpoint", "test-checkpoint"},
-	{"/api/v2/tile/1/2", "test-tile:1,2"},
-	{"/api/v2/tile/1/2.p/3", "test-tile:1,2.p,3"},
-	{"/api/v2/tile/entries/1", "test-entries:1"},
-	{"/api/v2/tile/entries/1.p/2", "test-entries:1.p,2"},
+	{"/api/v2/tile/1/002", "test-tile:1,2,0"},
+	{"/api/v2/tile/1/x123/456", "test-tile:1,123456,0"},
+	{"/api/v2/tile/1/002.p/3", "test-tile:1,2,3"},
+	{"/api/v2/tile/entries/001", "test-entries:1,0"},
+	{"/api/v2/tile/entries/x123/456", "test-entries:123456,0"},
+	{"/api/v2/tile/entries/001.p/2", "test-entries:1,2"},
 	{"/healthz", `{"status":"SERVING"}` + "\n"},
 }
 

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -127,14 +127,8 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 func (s *Server) GetTile(context.Context, *pb.TileRequest) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTile not implemented")
 }
-func (s *Server) GetPartialTile(context.Context, *pb.PartialTileRequest) (*httpbody.HttpBody, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetPartialTile not implemented")
-}
 func (s *Server) GetEntryBundle(context.Context, *pb.EntryBundleRequest) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEntryBundle not implemented")
-}
-func (s *Server) GetPartialEntryBundle(context.Context, *pb.PartialEntryBundleRequest) (*httpbody.HttpBody, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetPartialEntryBundle not implemented")
 }
 func (s *Server) GetCheckpoint(context.Context, *emptypb.Empty) (*httpbody.HttpBody, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetCheckpoint not implemented")


### PR DESCRIPTION
Per C2SP/tlog-tiles, N should be encoded as zero-padded 3 digit path elements. While we could provide an API that takes an unsigned int as the index instead, this API would differ from how clients access tiles and entry bundles in GCS, which would be a leaky abstraction.

This change also simplifies the read API to remove separate APIs for partial tile requests, instead having the client encode the requested partial width in N as per C2SP/tlog-tiles.

Fixes #218

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
