### PR TITLE
Refactor ToLogEntry, extract validators and verifiers

### DIFF
--- a/pkg/algorithmregistry/algorithmregistry.go
+++ b/pkg/algorithmregistry/algorithmregistry.go
@@ -28,7 +28,7 @@ var (
 	// AllowedClientSigningAlgorithms is the default set of supported signing
 	// algorithms for log entry signatures.
 	// When adding a new PublicKeyDetails, hashAlgorithmOrder must be updated
-	// if the that uses a hash algorithm not specified in hashAlgorithmOrder
+	// if it uses a hash algorithm not specified in hashAlgorithmOrder.
 	AllowedClientSigningAlgorithms = []v1.PublicKeyDetails{
 		v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_2048_SHA256,
 		v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_3072_SHA256,
@@ -41,7 +41,7 @@ var (
 	}
 	// Opinionated ordering of hash algorithms from oldest and weakest to newest and strongest.
 	// Must be updated if AllowedClientSigningAlgorithms is updated with a new digest.
-	// Used to select payload hash algorithm for entry with multiple signatures
+	// Used to select payload hash algorithm for entry with multiple signatures.
 	hashAlgorithmOrder = []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512}
 )
 

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -169,6 +169,30 @@ func TestToLogEntry(t *testing.T) {
 			expectErr: fmt.Errorf("missing verifiers"),
 		},
 		{
+			name: "invalid verifier",
+			dsse: &pb.DSSERequestV0_0_2{
+				Envelope: &dsse.Envelope{
+					Payload:     []byte("payload"),
+					PayloadType: "application/vnd.in-toto+json",
+					Signatures: []*dsse.Signature{
+						{
+							Sig:   []byte("sig"),
+							Keyid: "",
+						},
+					},
+				},
+				Verifiers: []*pb.Verifier{
+					{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{},
+						},
+						KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+					},
+				},
+			},
+			expectErr: fmt.Errorf("invalid verifier"),
+		},
+		{
 			name: "missing signatures",
 			dsse: &pb.DSSERequestV0_0_2{
 				Envelope: &dsse.Envelope{

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -16,13 +16,14 @@ package hashedrekord
 
 import (
 	"bytes"
+	"crypto"
 	"fmt"
 	"reflect"
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/rekor-tiles/pkg/algorithmregistry"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
-	"github.com/sigstore/rekor-tiles/pkg/types/validator"
+	pbverifier "github.com/sigstore/rekor-tiles/pkg/types/verifier"
 	"github.com/sigstore/rekor-tiles/pkg/verifier"
 	"github.com/sigstore/rekor-tiles/pkg/verifier/certificate"
 	"github.com/sigstore/rekor-tiles/pkg/verifier/publickey"
@@ -30,22 +31,50 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
-// ToLogEntry validates a request and converts it to a log entry type for inclusion in the log
-// TODO(#178) separate out ToLogEntry into proto validation, cyrpto validation and log entry conversion
+// ToLogEntry validates a request, verifies its signature, and converts it to a log entry type for inclusion in the log
 func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.AlgorithmRegistryConfig) (*pb.HashedRekordLogEntryV0_0_2, error) {
-	if hr.Signature == nil || len(hr.Signature.Content) == 0 {
-		return nil, fmt.Errorf("missing signature")
-	}
-	if hr.Signature.Verifier == nil {
-		return nil, fmt.Errorf("missing verifier")
-	}
-	if len(hr.Digest) == 0 {
-		return nil, fmt.Errorf("missing digest")
-	}
-	if err := validator.Validate(hr.Signature.Verifier); err != nil {
+	if err := validate(hr); err != nil {
 		return nil, err
 	}
 
+	v, err := extractVerifier(hr)
+	if err != nil {
+		return nil, err
+	}
+
+	algDetails, err := verifySupportedAlgorithm(hr.Signature.Verifier.KeyDetails, v, algorithmRegistry)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := verifySignature(hr, v, algDetails.GetHashType()); err != nil {
+		return nil, err
+	}
+
+	return &pb.HashedRekordLogEntryV0_0_2{
+		Signature: hr.Signature,
+		Data:      &v1.HashOutput{Digest: hr.Digest, Algorithm: algDetails.GetProtoHashType()},
+	}, nil
+}
+
+// validate validates there are no missing fields in a HashedRekordRequestV0_0_2 protobuf
+func validate(hr *pb.HashedRekordRequestV0_0_2) error {
+	if hr.Signature == nil || len(hr.Signature.Content) == 0 {
+		return fmt.Errorf("missing signature")
+	}
+	if hr.Signature.Verifier == nil {
+		return fmt.Errorf("missing verifier")
+	}
+	if len(hr.Digest) == 0 {
+		return fmt.Errorf("missing digest")
+	}
+	if err := pbverifier.Validate(hr.Signature.Verifier); err != nil {
+		return fmt.Errorf("invalid verifier: %v", err)
+	}
+	return nil
+}
+
+func extractVerifier(hr *pb.HashedRekordRequestV0_0_2) (verifier.Verifier, error) {
 	var v verifier.Verifier
 	var err error
 	if pubKey := hr.Signature.Verifier.GetPublicKey(); pubKey != nil {
@@ -58,32 +87,36 @@ func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.A
 	if err != nil {
 		return nil, fmt.Errorf("parsing verifier: %w", err)
 	}
+	return v, nil
+}
 
-	algDetails, err := signature.GetAlgorithmDetails(hr.Signature.Verifier.KeyDetails)
+// verifySupportedAlgorithm confirms that the signature and digest algorithm pair is supported by this server
+// instance, and returns details about the signing algorithm to be used while verifying the entry signature.
+func verifySupportedAlgorithm(keyDetails v1.PublicKeyDetails, v verifier.Verifier, algorithmRegistry *signature.AlgorithmRegistryConfig) (signature.AlgorithmDetails, error) {
+	algDetails, err := signature.GetAlgorithmDetails(keyDetails)
 	if err != nil {
-		return nil, fmt.Errorf("getting key algorithm details: %w", err)
+		return signature.AlgorithmDetails{}, fmt.Errorf("getting key algorithm details: %w", err)
 	}
 	alg := algDetails.GetHashType()
 
 	valid, err := algorithmregistry.CheckEntryAlgorithms(v.PublicKey(), alg, algorithmRegistry)
 	if err != nil {
-		return nil, fmt.Errorf("checking entry algorithm: %w", err)
+		return signature.AlgorithmDetails{}, fmt.Errorf("checking entry algorithm: %w", err)
 	}
 	if !valid {
-		return nil, fmt.Errorf("unsupported entry algorithm for key %s, digest %s", reflect.TypeOf(v.PublicKey()), alg.String())
+		return signature.AlgorithmDetails{}, fmt.Errorf("unsupported entry algorithm for key %s, digest %s", reflect.TypeOf(v.PublicKey()), alg.String())
 	}
+	return algDetails, nil
+}
 
+func verifySignature(hr *pb.HashedRekordRequestV0_0_2, v verifier.Verifier, hashAlg crypto.Hash) error {
 	sigVerifier, err := signature.LoadVerifierWithOpts(v.PublicKey(), options.WithED25519ph())
 	if err != nil {
-		return nil, fmt.Errorf("loading verifier: %v", err)
+		return fmt.Errorf("loading verifier: %v", err)
 	}
 	if err := sigVerifier.VerifySignature(
-		bytes.NewReader(hr.Signature.Content), nil, options.WithDigest(hr.Digest), options.WithCryptoSignerOpts(alg)); err != nil {
-		return nil, fmt.Errorf("verifying signature: %w", err)
+		bytes.NewReader(hr.Signature.Content), nil, options.WithDigest(hr.Digest), options.WithCryptoSignerOpts(hashAlg)); err != nil {
+		return fmt.Errorf("verifying signature: %w", err)
 	}
-
-	return &pb.HashedRekordLogEntryV0_0_2{
-		Signature: hr.Signature,
-		Data:      &v1.HashOutput{Digest: hr.Digest, Algorithm: algDetails.GetProtoHashType()},
-	}, nil
+	return nil
 }

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -144,6 +144,22 @@ func TestToLogEntry(t *testing.T) {
 			expectErr: fmt.Errorf("missing digest"),
 		},
 		{
+			name: "invalid verifier",
+			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+				Signature: &pb.Signature{
+					Content: []byte("sig"),
+					Verifier: &pb.Verifier{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{},
+						},
+						KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+					},
+				},
+				Digest: []byte("digest"),
+			},
+			expectErr: fmt.Errorf("invalid verifier"),
+		},
+		{
 			name: "invalid signature",
 			hashedrekord: &pb.HashedRekordRequestV0_0_2{
 				Signature: &pb.Signature{

--- a/pkg/types/verifier/verifier.go
+++ b/pkg/types/verifier/verifier.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package validator
+package verifier
 
 import (
 	"fmt"
@@ -20,6 +20,7 @@ import (
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
 )
 
+// Validate validates there are no missing field in a Verifier protobuf
 func Validate(v *pb.Verifier) error {
 	publicKey := v.GetPublicKey()
 	x509Cert := v.GetX509Certificate()

--- a/pkg/types/verifier/verifier_test.go
+++ b/pkg/types/verifier/verifier_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package validator
+package verifier
 
 import (
 	"fmt"


### PR DESCRIPTION
Cleans up ToLogEntry for hashedrekord and dsse to try to make it more
explicit that the function is doing both request validation and
verificaction of entry signatures. Hashedrekord refactored very easily,
but DSSE is a bit more tricky given the repeated verifiers. May come
back to this later.

For now, refactored extracted functions remain unexported as an external
use case is not yet known.

Fixes https://github.com/sigstore/rekor-tiles/issues/178