### PR TITLE
Simplify payload hash calculation for DSSE

### DIFF
--- a/pkg/algorithmregistry/algorithmregistry_test.go
+++ b/pkg/algorithmregistry/algorithmregistry_test.go
@@ -15,7 +15,6 @@
 package algorithmregistry
 
 import (
-	"crypto"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,98 +58,6 @@ func TestAlgorithmRegistry(t *testing.T) {
 			}
 			assert.NoError(t, gotErr)
 			assert.NotNil(t, got)
-		})
-	}
-}
-
-func TestSelectHashAlgorithm(t *testing.T) {
-	testCases := []struct {
-		name           string
-		inputAlgs      []crypto.Hash
-		expectedHash   crypto.Hash
-		expectErr      bool
-		expectedErrMsg string
-	}{
-		{
-			name:         "Select strongest (SHA512)",
-			inputAlgs:    []crypto.Hash{crypto.SHA256, crypto.SHA512, crypto.SHA384},
-			expectedHash: crypto.SHA512,
-			expectErr:    false,
-		},
-		{
-			name:         "Select mid (SHA384)",
-			inputAlgs:    []crypto.Hash{crypto.SHA256, crypto.SHA384},
-			expectedHash: crypto.SHA384,
-			expectErr:    false,
-		},
-		{
-			name:         "Select only one",
-			inputAlgs:    []crypto.Hash{crypto.SHA256},
-			expectedHash: crypto.SHA256,
-			expectErr:    false,
-		},
-		{
-			name:         "Input already ordered",
-			inputAlgs:    []crypto.Hash{crypto.SHA512, crypto.SHA384, crypto.SHA256},
-			expectedHash: crypto.SHA512,
-			expectErr:    false,
-		},
-		{
-			name:         "Contains unknown algorithm (MD5)",
-			inputAlgs:    []crypto.Hash{crypto.MD5, crypto.SHA256, crypto.SHA384},
-			expectedHash: crypto.SHA384,
-			expectErr:    false,
-		},
-		{
-			name:           "Only unknown algorithms",
-			inputAlgs:      []crypto.Hash{crypto.MD5, crypto.SHA1},
-			expectedHash:   crypto.Hash(0),
-			expectErr:      true,
-			expectedErrMsg: "no known hash algorithms provided",
-		},
-		{
-			name:         "Duplicate algorithms",
-			inputAlgs:    []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA256, crypto.SHA512, crypto.SHA384},
-			expectedHash: crypto.SHA512,
-			expectErr:    false,
-		},
-		{
-			name:           "Empty slice",
-			inputAlgs:      []crypto.Hash{},
-			expectedHash:   crypto.Hash(0),
-			expectErr:      true,
-			expectedErrMsg: "hash algorithm slice is empty",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Make a copy, as the function modifies the input slice.
-			inputCopy := make([]crypto.Hash, len(tc.inputAlgs))
-			copy(inputCopy, tc.inputAlgs)
-
-			actualHash, actualErr := SelectHashAlgorithm(inputCopy)
-
-			if tc.expectErr {
-				if actualErr == nil {
-					t.Errorf("SelectHashAlgorithm() expected error, but got nil")
-					return
-				}
-				if actualErr.Error() != tc.expectedErrMsg {
-					t.Errorf("SelectHashAlgorithm() error = %q, want %q", actualErr.Error(), tc.expectedErrMsg)
-				}
-				if actualHash != crypto.Hash(0) {
-					t.Errorf("SelectHashAlgorithm() expected zero hash value on error, got %v", actualHash)
-				}
-			} else {
-				if actualErr != nil {
-					t.Errorf("SelectHashAlgorithm() returned unexpected error: %v", actualErr)
-					return
-				}
-				if actualHash != tc.expectedHash {
-					t.Errorf("SelectHashAlgorithm() hash = %v, want %v", actualHash, tc.expectedHash)
-				}
-			}
 		})
 	}
 }

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -16,7 +16,6 @@ package dsse
 
 import (
 	"crypto/sha256"
-	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -80,7 +79,6 @@ func TestToLogEntry(t *testing.T) {
 
 	var payload = []byte("payload")
 	var payloadHash = sha256.Sum256(payload)
-	var payloadHash384 = sha512.Sum384(payload)
 	var keySignature = b64DecodeOrDie(t, "MEUCIQCSWas1Y9bI7aDNrBdHlzrFH8ch7B7IM+pJK86mtjkbJAIgaeCltz6vs20DP2sJ7IBihvcrdqGn3ivuV/KNPlMOetk=")
 	var certSignature = b64DecodeOrDie(t, "MEUCIQDoYuLoinEz/gM6B+hEn/0d47lmRDitQ3LfL9vH0sF/gQIgPqVgoBTRsMSPYMXYuJYYCIaTpnuppqQaTSTRn0ubwLI=")
 	var keySignatureP384 = b64DecodeOrDie(t, "MGYCMQDdKEzOCt71AzF+KKxrDQgCcPtsnfPZORmPlFZutXFqM8y/fi77sEAOjYkVdc4xxJwCMQC/4JuQ/bDWQV4QzPRA/u03pG49iTUDskoCFIrmabe0XyC9JkY1yyeuNS2LixMCaCI=")
@@ -368,8 +366,8 @@ func TestToLogEntry(t *testing.T) {
 			},
 			expectedEntry: &pb.DSSELogEntryV0_0_2{
 				PayloadHash: &v1.HashOutput{
-					Algorithm: v1.HashAlgorithm_SHA2_384,
-					Digest:    payloadHash384[:],
+					Algorithm: v1.HashAlgorithm_SHA2_256,
+					Digest:    payloadHash[:],
 				},
 				Signatures: []*pb.Signature{
 					{
@@ -437,8 +435,8 @@ func TestToLogEntry(t *testing.T) {
 			},
 			expectedEntry: &pb.DSSELogEntryV0_0_2{
 				PayloadHash: &v1.HashOutput{
-					Algorithm: v1.HashAlgorithm_SHA2_384,
-					Digest:    payloadHash384[:],
+					Algorithm: v1.HashAlgorithm_SHA2_256,
+					Digest:    payloadHash[:],
 				},
 				Signatures: []*pb.Signature{
 					{


### PR DESCRIPTION
As described in the linked issue, clients cannot use the payload hash
when verifying signatures since there's no guarantee that the payload
hash algorithm matches the signature digest algorithm. Therefore, we can
simplify the payload hash output to just use a fixed digest. We pick the
hash alg that matches the leaf hash alg.

Fixes https://github.com/sigstore/rekor-tiles/issues/226

Signed-off-by: Hayden B <8418760+haydentherapper@users.noreply.github.com>