### PR TITLE
Update release workflow to support macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
-          subject-path: ./dist/**/rekor-server-*
+          subject-path: ./dist/rekor-server-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,15 +28,15 @@ sboms:
 
 builds:
   - id: rekor-server
-    binary: rekor-server-linux-{{ .Arch }}
+    binary: rekor-server-{{ .Os }}-{{ .Arch }}
     main: ./cmd/rekor-server
+    no_unique_dist_dir: true
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
       - arm64
-    goarm:
-      - 7
     flags:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
Drops unnecessary goarm as we only build for arm64, and build everything in the same directory to simplify the glob pattern.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
