### PR TITLE
Add consistency proof verification functions

### DIFF
--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -18,6 +18,7 @@ package verify
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -151,28 +152,28 @@ func TestVerifyCheckpoint(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name    string
-		entry   *pbs.TransparencyLogEntry
-		wantErr bool
+		name       string
+		checkpoint string
+		wantErr    bool
 	}{
 		{
-			name:    "valid checkpoint",
-			entry:   getTestEntry(t, sv, hostname),
-			wantErr: false,
+			name:       "valid checkpoint",
+			checkpoint: getTestEntry(t, sv, hostname).GetInclusionProof().GetCheckpoint().GetEnvelope(),
+			wantErr:    false,
 		},
 		{
-			name:    "hostname mismatch",
-			entry:   getTestEntry(t, sv, "other.host"),
-			wantErr: true,
+			name:       "hostname mismatch",
+			checkpoint: getTestEntry(t, sv, "other.host").GetInclusionProof().GetCheckpoint().GetEnvelope(),
+			wantErr:    true,
 		},
 		{
-			name:    "signature mismatch",
-			entry:   getTestEntry(t, otherSigner, hostname),
-			wantErr: true,
+			name:       "signature mismatch",
+			checkpoint: getTestEntry(t, otherSigner, hostname).GetInclusionProof().GetCheckpoint().GetEnvelope(),
+			wantErr:    true,
 		},
 	} {
 		t.Run(string(test.name), func(t *testing.T) {
-			_, gotErr := VerifyCheckpoint(test.entry, noteVerifier)
+			_, gotErr := VerifyCheckpoint(test.checkpoint, noteVerifier)
 			if (gotErr != nil) != test.wantErr {
 				t.Fatalf("VerifyCheckpoint = %t, wantErr %t", gotErr, test.wantErr)
 			}
@@ -229,5 +230,61 @@ func TestVerifyLogEntry(t *testing.T) {
 	}
 
 	gotErr := VerifyLogEntry(entry, noteVerifier)
+	assert.NoError(t, gotErr)
+}
+
+func TestVerifyConsistencyProof(t *testing.T) {
+	hostname := "rekor.localhost"
+	root1, err := hex.DecodeString("59a575f157274702c38de3ab1e1784226f391fb79500ebf9f02b4439fb77574c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root2, err := hex.DecodeString("5be1758dd2228acfaf2546b4b6ce8aa40c82a3748f3dcb550e0d67ba34f02a45")
+	if err != nil {
+		t.Fatal(err)
+	}
+	consistencyHashes, err := hex.DecodeString("d3be742c8d73e2dd3c5635843e987ad3dfb3837616f412a07bf730c3ad73f5cb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sv, _, err := signature.NewDefaultECDSASignerVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	noteVerifier, err := rekornote.NewNoteVerifier(hostname, sv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noteSigner, err := rekornote.NewNoteSigner(context.Background(), hostname, sv)
+	if err != nil {
+		t.Fatal(err)
+
+	}
+
+	oldCpRaw := f_log.Checkpoint{
+		Origin: hostname,
+		Size:   1,
+		Hash:   root1,
+	}.Marshal()
+	oldCp, err := note.Sign(&note.Note{Text: string(oldCpRaw)}, noteSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newCpRaw := f_log.Checkpoint{
+		Origin: hostname,
+		Size:   2,
+		Hash:   root2,
+	}.Marshal()
+	newCp, err := note.Sign(&note.Note{Text: string(newCpRaw)}, noteSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotErr := VerifyConsistencyProofWithCheckpoints([][]byte{consistencyHashes}, string(oldCp), string(newCp), noteVerifier)
+	assert.NoError(t, gotErr)
+
+	gotErr = VerifyConsistencyProof([][]byte{consistencyHashes}, 1, root1, string(newCp), noteVerifier)
 	assert.NoError(t, gotErr)
 }


### PR DESCRIPTION
These will be used by log monitors and/or witnesses to verify consistency proofs, which the client is required to build.

Fixes #197

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
