### PR TITLE
Prevent concurrent releases

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -30,6 +30,11 @@ env:
 
 permissions: {}
 
+# Prevent concurrent runs of this workflow, but do not cancel any in-progress
+concurrency:
+  group: "build-container"
+  cancel-in-progress: false
+
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,10 @@ on:
     tags:
       - "v*"
 
-concurrency: create-release
+# Prevent concurrent runs of this workflow, but do not cancel any in-progress
+concurrency:
+  group: "create-release"
+  cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
This prevents two concurrent releases or container builds from overwriting one another.

Signed-off-by: Hayden B <haydentherapper@users.noreply.github.com>