### PR TITLE
Better logging for unsupported signature algorithm

### DIFF
--- a/pkg/algorithmregistry/algorithmregistry_test.go
+++ b/pkg/algorithmregistry/algorithmregistry_test.go
@@ -15,6 +15,12 @@
 package algorithmregistry
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +64,121 @@ func TestAlgorithmRegistry(t *testing.T) {
 			}
 			assert.NoError(t, gotErr)
 			assert.NotNil(t, got)
+		})
+	}
+}
+
+func generateRSAKey(t *testing.T, bits int) *rsa.PublicKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	return &priv.PublicKey
+}
+
+func generateECDSAKey(t *testing.T, curve elliptic.Curve) *ecdsa.PublicKey {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+	return &priv.PublicKey
+}
+
+func generateEd25519Key(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate Ed25519 key: %v", err)
+	}
+	return pub
+}
+
+func TestUnsupportedAlgorithm_Error(t *testing.T) {
+	rsaKey2048 := generateRSAKey(t, 2048)
+	rsaKey4096 := generateRSAKey(t, 4096)
+	ecdsaKeyP256 := generateECDSAKey(t, elliptic.P256())
+	ecdsaKeyP384 := generateECDSAKey(t, elliptic.P384())
+	ed25519Key := generateEd25519Key(t)
+
+	testCases := []struct {
+		name string
+		err  UnsupportedAlgorithm
+		want string
+	}{
+		{
+			name: "RSA 2048 with SHA256",
+			err: UnsupportedAlgorithm{
+				Pub: rsaKey2048,
+				Alg: crypto.SHA256,
+			},
+			want: "unsupported entry algorithm for RSA key, size 2048, digest SHA-256",
+		},
+		{
+			name: "RSA 4096 with SHA512",
+			err: UnsupportedAlgorithm{
+				Pub: rsaKey4096,
+				Alg: crypto.SHA512,
+			},
+			want: "unsupported entry algorithm for RSA key, size 4096, digest SHA-512",
+		},
+		{
+			name: "ECDSA P256 with SHA256",
+			err: UnsupportedAlgorithm{
+				Pub: ecdsaKeyP256,
+				Alg: crypto.SHA256,
+			},
+			want: "unsupported entry algorithm for ECDSA key, curve P-256, digest SHA-256",
+		},
+		{
+			name: "ECDSA P384 with SHA384",
+			err: UnsupportedAlgorithm{
+				Pub: ecdsaKeyP384,
+				Alg: crypto.SHA384,
+			},
+			want: "unsupported entry algorithm for ECDSA key, curve P-384, digest SHA-384",
+		},
+		{
+			name: "Ed25519 with SHA256",
+			err: UnsupportedAlgorithm{
+				Pub: ed25519Key,
+				Alg: crypto.SHA256,
+			},
+			want: "unsupported entry algorithm for Ed25519 key, digest SHA-256",
+		},
+		{
+			name: "nil public key",
+			err: UnsupportedAlgorithm{
+				Pub: nil,
+				Alg: crypto.SHA256,
+			},
+			want: "unsupported key type %!s(<nil>), digest SHA-256",
+		},
+		{
+			name: "unknown public key type",
+			err: UnsupportedAlgorithm{
+				Pub: int(1),
+				Alg: crypto.SHA256,
+			},
+			want: "unsupported key type int, digest SHA-256",
+		},
+		{
+			name: "zero hash value",
+			err: UnsupportedAlgorithm{
+				Pub: rsaKey2048,
+				Alg: crypto.Hash(0),
+			},
+			want: "unsupported entry algorithm for RSA key, size 2048, digest unknown hash value 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.Error()
+			if got != tc.want {
+				t.Errorf("Error() mismatch:\ngot = %q\nwant= %q", got, tc.want)
+			}
 		})
 	}
 }

--- a/pkg/types/dsse/dsse.go
+++ b/pkg/types/dsse/dsse.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -157,7 +156,7 @@ func verifyEnvelopeAndSupportedAlgs(verifiers map[*pb.Verifier]verifier.Verifier
 			return nil, fmt.Errorf("checking entry algorithm: %w", err)
 		}
 		if !valid {
-			return nil, fmt.Errorf("unsupported entry algorithm for key %s, digest %s", reflect.TypeOf(verifierKey.PublicKey()), alg.String())
+			return nil, &algorithmregistry.UnsupportedAlgorithm{Pub: verifierKey.PublicKey(), Alg: alg}
 		}
 
 		vfr, err := signature.LoadVerifier(verifierKey.PublicKey(), alg)

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -326,7 +326,7 @@ func TestToLogEntry(t *testing.T) {
 				},
 			},
 			allowedAlgorithms: []v1.PublicKeyDetails{v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256, v1.PublicKeyDetails_PKIX_ED25519_PH},
-			expectErr:         fmt.Errorf("unsupported entry algorithm for key *ecdsa.PublicKey, digest SHA-256"),
+			expectErr:         fmt.Errorf("unsupported entry algorithm for ECDSA key, curve P-256, digest SHA-256"),
 		},
 		{
 			name: "valid DSSE with multiple signatures, different algorithm",

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto"
 	"fmt"
-	"reflect"
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/rekor-tiles/pkg/algorithmregistry"
@@ -104,7 +103,7 @@ func verifySupportedAlgorithm(keyDetails v1.PublicKeyDetails, v verifier.Verifie
 		return signature.AlgorithmDetails{}, fmt.Errorf("checking entry algorithm: %w", err)
 	}
 	if !valid {
-		return signature.AlgorithmDetails{}, fmt.Errorf("unsupported entry algorithm for key %s, digest %s", reflect.TypeOf(v.PublicKey()), alg.String())
+		return signature.AlgorithmDetails{}, &algorithmregistry.UnsupportedAlgorithm{Pub: v.PublicKey(), Alg: alg}
 	}
 	return algDetails, nil
 }

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -211,7 +211,7 @@ func TestToLogEntry(t *testing.T) {
 				Digest: hexDecodeOrDie(t, hexEncodedDigest),
 			},
 			allowedAlgorithms: []v1.PublicKeyDetails{v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256, v1.PublicKeyDetails_PKIX_ED25519_PH},
-			expectErr:         fmt.Errorf("unsupported entry algorithm for key *ecdsa.PublicKey, digest SHA-256"),
+			expectErr:         fmt.Errorf("unsupported entry algorithm for ECDSA key, curve P-256, digest SHA-256"),
 		},
 		{
 			name: "valid hashedrekord with different algorithm",


### PR DESCRIPTION
This adds the RSA key size or ECDSA curve name for easier debugging. Otherwise, we only get the signature and hash algorithms and can't match the rejection to a specific PublicKeyDetails.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
