### PR TITLE
Move antispam initialization under GCP backend

### DIFF
--- a/pkg/tessera/gcp.go
+++ b/pkg/tessera/gcp.go
@@ -21,6 +21,7 @@ import (
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	antispam "github.com/transparency-dev/trillian-tessera/storage/gcp/antispam"
 )
 
 // NewGCPDriver returns a GCP Tessera Driver for the given bucket and spanner URI.
@@ -34,4 +35,14 @@ func NewGCPDriver(ctx context.Context, bucket, spanner string) (tessera.Driver, 
 		return nil, fmt.Errorf("getting tessera GCP driver: %w", err)
 	}
 	return driver, nil
+}
+
+// NewGCPAntispam initializes a Spanner database to store recent entries
+func NewGCPAntispam(ctx context.Context, spannerDb string, maxBatchSize, pushbackThreshold uint) (tessera.Antispam, error) {
+	asOpts := antispam.AntispamOpts{
+		MaxBatchSize:      maxBatchSize,
+		PushbackThreshold: pushbackThreshold,
+	}
+	dbName := fmt.Sprintf("%s-antispam", spannerDb)
+	return antispam.NewAntispam(ctx, dbName, asOpts)
 }

--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -30,16 +30,13 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/client"
-	antispam "github.com/transparency-dev/trillian-tessera/storage/gcp/antispam"
 )
 
 const (
-	DefaultBatchMaxSize              = tessera.DefaultBatchMaxSize
-	DefaultBatchMaxAge               = tessera.DefaultBatchMaxAge
-	DefaultCheckpointInterval        = tessera.DefaultCheckpointInterval
-	DefaultPushbackMaxOutstanding    = tessera.DefaultPushbackMaxOutstanding
-	DefaultAntispamMaxBatchSize      = antispam.DefaultMaxBatchSize
-	DefaultAntispamPushbackThreshold = antispam.DefaultPushbackThreshold
+	DefaultBatchMaxSize           = tessera.DefaultBatchMaxSize
+	DefaultBatchMaxAge            = tessera.DefaultBatchMaxAge
+	DefaultCheckpointInterval     = tessera.DefaultCheckpointInterval
+	DefaultPushbackMaxOutstanding = tessera.DefaultPushbackMaxOutstanding
 )
 
 type DuplicateError struct {
@@ -93,25 +90,46 @@ func WithLifecycleOptions(opts *tessera.AppendOptions, batchMaxSize uint, baxMax
 }
 
 // WithAntispamOptions accepts an initialized AppendOptions and adds antispam options to it.
-// Set persistent=true to set up configuration for the persistent antispam Spanner database.
-// It returns the mutated options object for readability.
-func WithAntispamOptions(ctx context.Context, opts *tessera.AppendOptions, persistent bool, maxBatchSize, pushbackThreshold uint, spannerDB string) (*tessera.AppendOptions, error) {
+// Accepts an optional persistent antispam provider. If nil, antispam does not persist between
+// server restarts. Returns the mutated options object for readability.
+func WithAntispamOptions(opts *tessera.AppendOptions, as tessera.Antispam) *tessera.AppendOptions {
 	inMemoryLRUSize := uint(256) // There's no documentation providing guidance on this cache size. Use a hard-coded value for now and consider exposing it as a configuration option later.
-	if !persistent {
-		opts = opts.WithAntispam(inMemoryLRUSize, nil)
-		return opts, nil
-	}
-	asOpts := antispam.AntispamOpts{
-		MaxBatchSize:      maxBatchSize,
-		PushbackThreshold: pushbackThreshold,
-	}
-	dbName := fmt.Sprintf("%s-antispam", spannerDB)
-	as, err := antispam.NewAntispam(ctx, dbName, asOpts)
-	if err != nil {
-		return nil, fmt.Errorf("getting antispam storage: %w", err)
-	}
 	opts = opts.WithAntispam(inMemoryLRUSize, as)
-	return opts, nil
+	return opts
+}
+
+// DriverConfiguration contains storage-specific configuration for each supported storage backend.
+type DriverConfiguration struct {
+	// GCP configuration
+	GCPBucket    string
+	GCPSpannerDB string
+
+	// Antispam configuration
+	PersistentAntispam  bool
+	ASMaxBatchSize      uint
+	ASPushbackThreshold uint
+}
+
+// NewDriver creates a Tessera driver and optional persistent antispam for a given storage backend.
+func NewDriver(ctx context.Context, config DriverConfiguration) (tessera.Driver, tessera.Antispam, error) {
+	switch {
+	case config.GCPBucket != "" && config.GCPSpannerDB != "":
+		driver, err := NewGCPDriver(ctx, config.GCPBucket, config.GCPSpannerDB)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialize GCP driver: %v", err.Error())
+		}
+		var persistentAntispam tessera.Antispam
+		if config.PersistentAntispam {
+			as, err := NewGCPAntispam(ctx, config.GCPSpannerDB, config.ASMaxBatchSize, config.ASPushbackThreshold)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to initialize GCP antispam: %v", err.Error())
+			}
+			persistentAntispam = as
+		}
+		return driver, persistentAntispam, nil
+	default:
+		return nil, nil, fmt.Errorf("no flags provided to initialize Tessera driver")
+	}
 }
 
 // NewStorage creates a Tessera storage object for the provided driver and signer.

--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -159,6 +159,5 @@ func TestAppendOptions(t *testing.T) {
 	assert.Equal(t, 42*time.Millisecond, ao.BatchMaxAge())
 	assert.Equal(t, 42*time.Second, ao.CheckpointInterval())
 	assert.Equal(t, uint(42), ao.PushbackMaxOutstanding())
-	_, err = WithAntispamOptions(context.Background(), ao, false, 100, 1000, "spannerdb")
-	assert.NoError(t, err)
+	_ = WithAntispamOptions(ao, nil) // initializes non-persistent antispam
 }


### PR DESCRIPTION
As future Tessera backends are added, each will need its own antispam initialization.

This also changes the default values for antispam pushback and max batch size to 0. When zero, the Tessera library will set the default. This is needed because each antispam backend has its own defaults.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
