### PR TITLE
Implement APIs for read server

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sigstore/rekor-tiles/pkg/signerverifier"
 	"github.com/sigstore/rekor-tiles/pkg/tessera"
 	"github.com/sigstore/sigstore/pkg/signature"
+	tesseraLib "github.com/transparency-dev/trillian-tessera"
 )
 
 var serveCmd = &cobra.Command{
@@ -49,12 +50,36 @@ var serveCmd = &cobra.Command{
 		}
 		slog.Info("starting rekor-server", "version", versionInfoStr)
 
+		readOnly := viper.GetBool("read-only")
+		persistentAntispam := viper.GetBool("persistent-antispam")
+		asMaxBatchSize := viper.GetUint("antispam-max-batch-size")
+		asPushbackThreshold := viper.GetUint("antispam-pushback-threshold")
+
+		gcpBucket := viper.GetString("gcp-bucket")
+		gcpSpannerDb := viper.GetString("gcp-spanner")
+
 		// currently only the GCP driver is supported for rekor-tiles.
-		tesseraDriver, err := tessera.NewGCPDriver(ctx, viper.GetString("gcp-bucket"), viper.GetString("gcp-spanner"))
-		if err != nil {
-			slog.Error(fmt.Sprintf("failed to initialize GCP driver: %v", err.Error()))
+		var tesseraDriver tesseraLib.Driver
+		var antispamProvider tesseraLib.Antispam
+		switch {
+		case gcpBucket != "" && gcpSpannerDb != "":
+			tesseraDriver, err = tessera.NewGCPDriver(ctx, gcpBucket, gcpSpannerDb)
+			if err != nil {
+				slog.Error(fmt.Sprintf("failed to initialize GCP driver: %v", err.Error()))
+				os.Exit(1)
+			}
+			if !readOnly && persistentAntispam {
+				antispamProvider, err = tessera.NewGCPAntispam(ctx, gcpSpannerDb, asMaxBatchSize, asPushbackThreshold)
+				if err != nil {
+					slog.Error(fmt.Sprintf("failed to initialize GCP antispam: %v", err.Error()))
+					os.Exit(1)
+				}
+			}
+		default:
+			slog.Error("no flags provided to initialize Tessera driver")
 			os.Exit(1)
 		}
+
 		var signerOpts []signerverifier.Option
 		switch {
 		case viper.GetString("signer-filepath") != "":
@@ -83,13 +108,12 @@ var serveCmd = &cobra.Command{
 			slog.Error(fmt.Sprintf("failed to initialize append options: %v", err))
 			os.Exit(1)
 		}
-		readOnly := viper.GetBool("read-only")
 		var tesseraStorage tessera.Storage
 		shutdownFn := func(_ context.Context) error { return nil }
 		// if in read-only mode, don't start the appender, because we don't want new checkpoints being published.
 		if !readOnly {
 			appendOptions = tessera.WithLifecycleOptions(appendOptions, viper.GetUint("batch-max-size"), viper.GetDuration("batch-max-age"), viper.GetDuration("checkpoint-interval"), viper.GetUint("pushback-max-outstanding"))
-			appendOptions, err = tessera.WithAntispamOptions(ctx, appendOptions, viper.GetBool("persistent-antispam"), viper.GetUint("antispam-max-batch-size"), viper.GetUint("antispam-pushback-threshold"), viper.GetString("gcp-spanner"))
+			appendOptions = tessera.WithAntispamOptions(appendOptions, antispamProvider)
 			if err != nil {
 				slog.Error(fmt.Sprintf("failed to configure antispam append options: %v", err))
 				os.Exit(1)
@@ -169,8 +193,8 @@ func init() {
 
 	// antispam configs
 	serveCmd.Flags().Bool("persistent-antispam", false, "whether to enable persistent antispam measures; only available for GCP storage backend and not supported by the Spanner storage emulator")
-	serveCmd.Flags().Uint("antispam-max-batch-size", tessera.DefaultAntispamMaxBatchSize, "maximum batch size for deduplication operations; recommend around 1500 for Spanner instances with 300 or more PU, or around 64 for smaller (e.g. 100 PU) instances")
-	serveCmd.Flags().Uint("antispam-pushback-threshold", tessera.DefaultAntispamPushbackThreshold, "maximum number of 'in-flight' add requests the antispam operator will allow before pushing back")
+	serveCmd.Flags().Uint("antispam-max-batch-size", 0, "maximum batch size for deduplication operations; will default to Tessera recommendation if unset; for Spanner, recommend around 1500 with 300 or more PU, or around 64 for smaller (e.g. 100 PU) instances")
+	serveCmd.Flags().Uint("antispam-pushback-threshold", 0, "maximum number of 'in-flight' add requests the antispam operator will allow before pushing back; will default to Tessera recommendation if unset")
 
 	// allowed entry signing algorithms
 	keyAlgorithmTypes, err := defaultKeyAlgorithms()

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -130,7 +130,12 @@ var serveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		rekorServer := server.NewServer(tesseraStorage, readOnly, algorithmRegistry)
+		var rekorServer server.RekorServer
+		if viper.GetBool("serve-read-paths") {
+			rekorServer = server.NewReadServer(tesseraStorage, readOnly, algorithmRegistry)
+		} else {
+			rekorServer = server.NewServer(tesseraStorage, readOnly, algorithmRegistry)
+		}
 
 		server.Serve(
 			ctx,
@@ -165,6 +170,7 @@ func init() {
 	serveCmd.Flags().String("grpc-address", "127.0.0.1", "GRPC address to bind to")
 	serveCmd.Flags().Duration("timeout", 60*time.Second, "timeout")
 	serveCmd.Flags().Int("max-request-body-size", 4*1024*1024, "maximum request body size in bytes")
+	serveCmd.Flags().Bool("serve-read-paths", false, "whether to serve the read paths /checkpoint and /tile from the filesystem, as an alternative to a standalone read traffic server")
 
 	// hostname
 	hostname, err := os.Hostname()

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,7 @@
 services:
   spanner:
     image: gcr.io/cloud-spanner-emulator/emulator:1.5.33@sha256:b211c813058e95bbdabfcb5dc78de0deb2d8a51e071532b2e90485fc6ec3a877
+    platform: linux/amd64
   gcs:
     image: fsouza/fake-gcs-server:1.52.2@sha256:d47b4cf8b87006cab8fbbecfa5f06a2a3c5722e464abddc0d107729663d40ec4
     volumes:
@@ -62,6 +63,7 @@ services:
     - "--gcp-spanner=projects/rekor-tiles-e2e/instances/rekor-tiles/databases/sequencer"
     - "--signer-filepath=/pki/ed25519-priv-key.pem"
     - "--checkpoint-interval=2s"
+    - "--serve-read-paths=true"
     ports:
     - "3003:3000" # http port
     - "3001:3001" # grpc port

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -52,8 +52,8 @@ type grpcServer struct {
 	serverEndpoint string
 }
 
-// newGRPCServer starts a new grpc server and registers the services.
-func newGRPCServer(config *GRPCConfig, server rekorServer) *grpcServer {
+// newGRPCServer starts a new gRPC server and registers the services
+func newGRPCServer(config *GRPCConfig, server RekorServer) *grpcServer {
 	var opts []grpc.ServerOption
 
 	grpcPanicRecoveryHandler := func(p any) (err error) {

--- a/pkg/server/grpc_test.go
+++ b/pkg/server/grpc_test.go
@@ -38,7 +38,7 @@ func TestServe_grpcSmoke(t *testing.T) {
 	server.Start(t)
 	defer server.Stop(t)
 
-	// check if we can hit grpc endpoints
+	// check if we can hit gRPC endpoints
 	conn, err := grpc.NewClient(
 		server.gc.GRPCTarget(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/pkg/server/serve.go
+++ b/pkg/server/serve.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 )
 
-// Serve starts the grpc server and its http proxy.
-func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s rekorServer, tesseraShutdownFn func(context.Context) error) {
+// Serve starts the gRPC server and HTTP proxy
+func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, s RekorServer, tesseraShutdownFn func(context.Context) error) {
 	var wg sync.WaitGroup
 
 	if hc.port == 0 || gc.port == 0 {

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -39,12 +39,13 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// rekorServer is the collection of methods that our grpc server must implement.
-type rekorServer interface {
+// RekorServer is the collection of methods that the gRPC server must implement
+type RekorServer interface {
 	pb.RekorServer
 	grpc_health_v1.HealthServer
 }
 
+// Server implements the write path and default healthcheck for all storage backends
 type Server struct {
 	pb.UnimplementedRekorServer
 	grpc_health_v1.UnimplementedHealthServer

--- a/pkg/server/service_read.go
+++ b/pkg/server/service_read.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"github.com/sigstore/rekor-tiles/pkg/tessera"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ReadServer implements the read APIs along with the write APIs
+type ReadServer struct {
+	Server
+}
+
+func NewReadServer(storage tessera.Storage, readOnly bool, algorithmRegistry *signature.AlgorithmRegistryConfig) *ReadServer {
+	if readOnly {
+		return &ReadServer{
+			Server: Server{
+				readOnly: readOnly,
+				storage:  storage,
+			},
+		}
+	}
+	return &ReadServer{
+		Server: Server{
+			storage:           storage,
+			algorithmRegistry: algorithmRegistry,
+		},
+	}
+}
+
+func (s *ReadServer) GetTile(ctx context.Context, req *pb.TileRequest) (*httpbody.HttpBody, error) {
+	// Verifies and parses level, index, and optional width for partial tile
+	l, i, w, err := layout.ParseTileLevelIndexPartial(strconv.FormatUint(uint64(req.L), 10), req.N)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid level, index and optional width")
+	}
+	tile, err := s.storage.ReadTile(ctx, l, i, w)
+	if err != nil {
+		return nil, status.Error(codes.Unknown, "failed to read tile")
+	}
+	_ = grpc.SetHeader(ctx, metadata.Pairs(httpCacheControlHeader, "max-age=31536000, immutable"))
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        tile,
+	}, nil
+}
+
+func (s *ReadServer) GetEntryBundle(ctx context.Context, req *pb.EntryBundleRequest) (*httpbody.HttpBody, error) {
+	// Parses index and optional width for partial tile
+	i, w, err := layout.ParseTileIndexPartial(req.N)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid index and optional width")
+	}
+	entryBundle, err := s.storage.ReadEntryBundle(ctx, i, w)
+	if err != nil {
+		return nil, status.Error(codes.Unknown, "failed to read entry bundle")
+	}
+	_ = grpc.SetHeader(ctx, metadata.Pairs(httpCacheControlHeader, "max-age=31536000, immutable"))
+	return &httpbody.HttpBody{
+		ContentType: "application/octet-stream",
+		Data:        entryBundle,
+	}, nil
+}
+
+func (s *ReadServer) GetCheckpoint(ctx context.Context, _ *emptypb.Empty) (*httpbody.HttpBody, error) {
+	checkpoint, err := s.storage.ReadCheckpoint(ctx)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, status.Error(codes.NotFound, "checkpoint does not exist")
+		}
+		return nil, status.Error(codes.Unknown, "failed to read checkpoint")
+	}
+	_ = grpc.SetHeader(ctx, metadata.Pairs(httpCacheControlHeader, "no-cache"))
+	return &httpbody.HttpBody{
+		ContentType: "text/plain; charset=utf-8",
+		Data:        checkpoint,
+	}, nil
+}

--- a/pkg/server/service_read_test.go
+++ b/pkg/server/service_read_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	rekor_pb "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor-tiles/pkg/algorithmregistry"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"github.com/stretchr/testify/assert"
+	ttessera "github.com/transparency-dev/trillian-tessera"
+	"google.golang.org/grpc"
+)
+
+func TestNewReadServer(t *testing.T) {
+	storage := &mockReadStorage{}
+	algReg, err := algorithmregistry.AlgorithmRegistry([]string{"ecdsa-sha2-256-nistp256"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewReadServer(storage, false, algReg)
+	assert.NoError(t, err)
+	assert.NotNil(t, server.storage)
+	assert.NotNil(t, server.algorithmRegistry)
+}
+
+func TestGetTile(t *testing.T) {
+	tests := []struct {
+		name        string
+		readFn      func() ([]byte, error)
+		req         *pb.TileRequest
+		expectError error
+	}{
+		{
+			name:   "valid entry bundle request with index and width",
+			readFn: func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:    &pb.TileRequest{L: 1, N: "x123/456.p/7"},
+		},
+		{
+			name:   "valid entry bundle request with index",
+			readFn: func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:    &pb.TileRequest{L: 1, N: "x123/456"},
+		},
+		{
+			name:        "invalid tile index",
+			readFn:      func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:         &pb.TileRequest{L: 0, N: "invalid"},
+			expectError: fmt.Errorf("invalid level, index and optional width"),
+		},
+		{
+			name:        "error reading entry bundle",
+			readFn:      func() ([]byte, error) { return nil, fmt.Errorf("error") },
+			req:         &pb.TileRequest{L: 1, N: "123"},
+			expectError: fmt.Errorf("failed to read tile"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := &mockReadStorage{readFn: test.readFn}
+			server := NewReadServer(storage, false, nil)
+			stream := runtime.ServerTransportStream{} // for gRPC headers
+			ctx := grpc.NewContextWithServerTransportStream(context.Background(), &stream)
+			gotResp, gotErr := server.GetTile(ctx, test.req)
+			if test.expectError == nil {
+				assert.NoError(t, gotErr)
+				assert.NotNil(t, gotResp)
+				assert.NotEmpty(t, gotResp.Data)
+				assert.Equal(t, gotResp.ContentType, "application/octet-stream")
+				vals := stream.Header().Get(httpCacheControlHeader)
+				assert.Len(t, vals, 1)
+				assert.Equal(t, vals[0], "max-age=31536000, immutable")
+			} else {
+				assert.ErrorContains(t, gotErr, test.expectError.Error())
+			}
+		})
+	}
+}
+
+func TestGetEntryBundle(t *testing.T) {
+	tests := []struct {
+		name        string
+		readFn      func() ([]byte, error)
+		req         *pb.EntryBundleRequest
+		expectError error
+	}{
+		{
+			name:   "valid entry bundle request with index and width",
+			readFn: func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:    &pb.EntryBundleRequest{N: "x123/456.p/7"},
+		},
+		{
+			name:   "valid entry bundle request with index",
+			readFn: func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:    &pb.EntryBundleRequest{N: "x123/456"},
+		},
+		{
+			name:        "invalid tile index",
+			readFn:      func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+			req:         &pb.EntryBundleRequest{N: "invalid"},
+			expectError: fmt.Errorf("invalid index and optional width"),
+		},
+		{
+			name:        "error reading entry bundle",
+			readFn:      func() ([]byte, error) { return nil, fmt.Errorf("error") },
+			req:         &pb.EntryBundleRequest{N: "123"},
+			expectError: fmt.Errorf("failed to read entry bundle"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := &mockReadStorage{readFn: test.readFn}
+			server := NewReadServer(storage, false, nil)
+			stream := runtime.ServerTransportStream{} // for gRPC headers
+			ctx := grpc.NewContextWithServerTransportStream(context.Background(), &stream)
+			gotResp, gotErr := server.GetEntryBundle(ctx, test.req)
+			if test.expectError == nil {
+				assert.NoError(t, gotErr)
+				assert.NotNil(t, gotResp)
+				assert.NotEmpty(t, gotResp.Data)
+				assert.Equal(t, gotResp.ContentType, "application/octet-stream")
+				vals := stream.Header().Get(httpCacheControlHeader)
+				assert.Len(t, vals, 1)
+				assert.Equal(t, vals[0], "max-age=31536000, immutable")
+			} else {
+				assert.ErrorContains(t, gotErr, test.expectError.Error())
+			}
+		})
+	}
+}
+
+func TestGetCheckpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		readFn      func() ([]byte, error)
+		expectError error
+	}{
+		{
+			name:   "valid checkpoint",
+			readFn: func() ([]byte, error) { return []byte{1, 2, 3, 4}, nil },
+		},
+		{
+			name:        "error reading checkpoint",
+			readFn:      func() ([]byte, error) { return nil, fmt.Errorf("error") },
+			expectError: fmt.Errorf("failed to read checkpoint"),
+		},
+		{
+			name:        "no checkpoint",
+			readFn:      func() ([]byte, error) { return nil, os.ErrNotExist },
+			expectError: fmt.Errorf("checkpoint does not exist"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := &mockReadStorage{readFn: test.readFn}
+			server := NewReadServer(storage, false, nil)
+			stream := runtime.ServerTransportStream{} // for gRPC headers
+			ctx := grpc.NewContextWithServerTransportStream(context.Background(), &stream)
+			gotResp, gotErr := server.GetCheckpoint(ctx, nil)
+			if test.expectError == nil {
+				assert.NoError(t, gotErr)
+				assert.NotNil(t, gotResp)
+				assert.NotEmpty(t, gotResp.Data)
+				assert.Equal(t, gotResp.ContentType, "text/plain; charset=utf-8")
+				vals := stream.Header().Get(httpCacheControlHeader)
+				assert.Len(t, vals, 1)
+				assert.Equal(t, vals[0], "no-cache")
+			} else {
+				assert.ErrorContains(t, gotErr, test.expectError.Error())
+			}
+		})
+	}
+}
+
+type mockReadStorage struct {
+	readFn func() ([]byte, error)
+}
+
+func (s *mockReadStorage) Add(_ context.Context, _ *ttessera.Entry) (*rekor_pb.TransparencyLogEntry, error) {
+	return nil, nil
+}
+
+func (s *mockReadStorage) ReadTile(_ context.Context, _, _ uint64, _ uint8) ([]byte, error) {
+	return s.readFn()
+}
+
+func (s *mockReadStorage) ReadEntryBundle(_ context.Context, _ uint64, _ uint8) ([]byte, error) {
+	return s.readFn()
+}
+
+func (s *mockReadStorage) ReadCheckpoint(_ context.Context) ([]byte, error) {
+	return s.readFn()
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -209,6 +209,14 @@ func (s *mockStorage) ReadTile(_ context.Context, _, _ uint64, _ uint8) ([]byte,
 	return nil, nil
 }
 
+func (s *mockStorage) ReadEntryBundle(_ context.Context, _ uint64, _ uint8) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *mockStorage) ReadCheckpoint(_ context.Context) ([]byte, error) {
+	return nil, nil
+}
+
 func hexDecodeOrDie(t *testing.T, hash string) []byte {
 	decoded, err := hex.DecodeString(hash)
 	if err != nil {

--- a/pkg/tessera/gcp.go
+++ b/pkg/tessera/gcp.go
@@ -21,6 +21,7 @@ import (
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	antispam "github.com/transparency-dev/trillian-tessera/storage/gcp/antispam"
 )
 
 // NewGCPDriver returns a GCP Tessera Driver for the given bucket and spanner URI.
@@ -34,4 +35,14 @@ func NewGCPDriver(ctx context.Context, bucket, spanner string) (tessera.Driver, 
 		return nil, fmt.Errorf("getting tessera GCP driver: %w", err)
 	}
 	return driver, nil
+}
+
+// NewGCPAntispam initializes a Spanner database to store recent entries
+func NewGCPAntispam(ctx context.Context, spannerDb string, maxBatchSize, pushbackThreshold uint) (tessera.Antispam, error) {
+	asOpts := antispam.AntispamOpts{
+		MaxBatchSize:      maxBatchSize,
+		PushbackThreshold: pushbackThreshold,
+	}
+	dbName := fmt.Sprintf("%s-antispam", spannerDb)
+	return antispam.NewAntispam(ctx, dbName, asOpts)
 }

--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -60,13 +60,17 @@ func (e InclusionProofVerificationError) Error() string {
 type Storage interface {
 	Add(ctx context.Context, entry *tessera.Entry) (*rekor_pb.TransparencyLogEntry, error)
 	ReadTile(ctx context.Context, level, index uint64, p uint8) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error)
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
 }
 
 type storage struct {
-	origin     string
-	awaiter    *tessera.PublicationAwaiter
-	addFn      tessera.AddFn
-	readTileFn client.TileFetcherFunc
+	origin            string
+	awaiter           *tessera.PublicationAwaiter
+	addFn             tessera.AddFn
+	readTileFn        client.TileFetcherFunc
+	readEntryBundleFn client.EntryBundleFetcherFunc
+	readCheckpointFn  client.CheckpointFetcherFunc
 }
 
 // NewAppendOptions initializes the Tessera append options with a checkpoint signer, which is the only non-optional append option.
@@ -108,10 +112,12 @@ func NewStorage(ctx context.Context, origin string, driver tessera.Driver, appen
 	slog.Info("starting Tessera sequencer")
 	awaiter := tessera.NewPublicationAwaiter(ctx, reader.ReadCheckpoint, 1*time.Second)
 	return &storage{
-		origin:     origin,
-		awaiter:    awaiter,
-		addFn:      appender.Add,
-		readTileFn: reader.ReadTile,
+		origin:            origin,
+		awaiter:           awaiter,
+		addFn:             appender.Add,
+		readTileFn:        reader.ReadTile,
+		readEntryBundleFn: reader.ReadEntryBundle,
+		readCheckpointFn:  reader.ReadCheckpoint,
 	}, shutdown, nil
 }
 
@@ -144,6 +150,26 @@ func (s *storage) ReadTile(ctx context.Context, level, index uint64, p uint8) ([
 		return nil, fmt.Errorf("reading tile level %d index %d p %d: %w", level, index, p, err)
 	}
 	return tile, nil
+}
+
+// ReadEntryBundle looks up an entry bundle at the given index and optional width, and returns
+// the raw bytes of the entry bundle.
+func (s *storage) ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+	entry, err := s.readEntryBundleFn(ctx, index, p)
+	if err != nil {
+		return nil, fmt.Errorf("reading entry bundle index %d p %d: %w", index, p, err)
+	}
+	return entry, nil
+}
+
+// ReadCheckpoint returns the raw bytes of a checkpoint. An error is returned if
+// no checkpoint exists.
+func (s *storage) ReadCheckpoint(ctx context.Context) ([]byte, error) {
+	checkpoint, err := s.readCheckpointFn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading checkpoint: %v", err)
+	}
+	return checkpoint, nil
 }
 
 func (s *storage) addEntry(ctx context.Context, entry *tessera.Entry) (*SafeInt64, bool, []byte, error) {

--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -159,6 +159,4 @@ func TestAppendOptions(t *testing.T) {
 	assert.Equal(t, 42*time.Millisecond, ao.BatchMaxAge())
 	assert.Equal(t, 42*time.Second, ao.CheckpointInterval())
 	assert.Equal(t, uint(42), ao.PushbackMaxOutstanding())
-	_, err = WithAntispamOptions(context.Background(), ao, false, 100, 1000, "spannerdb")
-	assert.NoError(t, err)
 }


### PR DESCRIPTION
This allows for deployers to serve read traffic without a separate
CDN/proxy. This is discouraged for GCP, since it's more costly to serve
read traffic in terms of egress costs, but can be used for other
backends and for local testing.

Rebased on #269.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
