### PR TITLE
Include KindVersion in TLE response

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -25,6 +25,7 @@ import (
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
 	"github.com/sigstore/rekor-tiles/pkg/tessera"
+	"github.com/sigstore/rekor-tiles/pkg/types"
 	"github.com/sigstore/rekor-tiles/pkg/types/dsse"
 	"github.com/sigstore/rekor-tiles/pkg/types/hashedrekord"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -122,6 +123,12 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 		slog.Warn("failed to integrate entry", "error", err.Error())
 		return nil, status.Errorf(codes.Unknown, "failed to integrate entry")
 	}
+	kv, err := types.GetKindVersion(req)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid type, must be either hashedrekord or dsse")
+	}
+	tle.KindVersion = kv
+
 	_ = grpc.SetHeader(ctx, metadata.Pairs(httpStatusCodeHeader, "201"))
 	metricsCounter.Inc()
 	return tle, nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+)
+
+// GetKindVersion returns the entry kind and version for a given create request.
+func GetKindVersion(req *pb.CreateEntryRequest) (*pbs.KindVersion, error) {
+	switch req.GetSpec().(type) {
+	case *pb.CreateEntryRequest_HashedRekordRequestV0_0_2:
+		return &pbs.KindVersion{Kind: "hashedrekord", Version: "0.0.2"}, nil
+	case *pb.CreateEntryRequest_DsseRequestV0_0_2:
+		return &pbs.KindVersion{Kind: "dsse", Version: "0.0.2"}, nil
+	default:
+		// should not happen
+		return nil, fmt.Errorf("invalid type, request must be for hashedrekord or dsse")
+	}
+}

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+)
+
+func TestGetKindVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		request       *pb.CreateEntryRequest
+		expectedKind  *pbs.KindVersion
+		expectedError string
+	}{
+		{
+			name: "HashedRekordRequestV0_0_2",
+			request: &pb.CreateEntryRequest{
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{},
+			},
+			expectedKind: &pbs.KindVersion{Kind: "hashedrekord", Version: "0.0.2"},
+		},
+		{
+			name: "DsseRequestV0_0_2",
+			request: &pb.CreateEntryRequest{
+				Spec: &pb.CreateEntryRequest_DsseRequestV0_0_2{},
+			},
+			expectedKind: &pbs.KindVersion{Kind: "dsse", Version: "0.0.2"},
+		},
+		{
+			name: "Invalid type",
+			request: &pb.CreateEntryRequest{
+				Spec: nil,
+			},
+			expectedKind:  nil,
+			expectedError: "invalid type, request must be for hashedrekord or dsse",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kindVersion, err := GetKindVersion(tc.request)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s', but got nil", tc.expectedError)
+				} else if err.Error() != tc.expectedError {
+					t.Errorf("expected error '%s', but got '%s'", tc.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, but got '%s'", err.Error())
+				}
+			}
+			if !reflect.DeepEqual(tc.expectedKind, kindVersion) {
+				t.Errorf("expected kind version %v, but got %v", tc.expectedKind, kindVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a missing required field for the kind and version of the entry, so that clients will know how to parse the canonicalized body.

This is a much simpler approach to the type factory in Rekor. At this point, given there are only two types, I don't think we should reimplement the factory and simply use case statements.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
