### PR TITLE
Add log ID to TransparencyLogEntry response, TLE testing in e2e test

### DIFF
--- a/pkg/note/note.go
+++ b/pkg/note/note.go
@@ -92,68 +92,72 @@ func isValidName(name string) bool {
 	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
 }
 
-// genConformantKeyHash generates a 4-byte key ID for typical (non-ECDSA) keys.
-func genConformantKeyHash(name string, sigType, key []byte) uint32 {
+// genConformantKeyHash generates a truncated (4-byte) and non-truncated
+// identifier for typical (non-ECDSA) keys.
+func genConformantKeyHash(name string, sigType, key []byte) (uint32, []byte) {
 	hash := sha256.New()
 	hash.Write([]byte(name))
 	hash.Write([]byte("\n"))
 	hash.Write(sigType)
 	hash.Write(key)
 	sum := hash.Sum(nil)
-	return binary.BigEndian.Uint32(sum)
+	return binary.BigEndian.Uint32(sum), sum
 }
 
 // ed25519KeyHash generates the 4-byte key ID for an Ed25519 public key.
 // Ed25519 keys are the only key type compatible with witnessing.
-func ed25519KeyHash(name string, key []byte) uint32 {
+func ed25519KeyHash(name string, key []byte) (uint32, []byte) {
 	return genConformantKeyHash(name, []byte{algEd25519}, key)
 }
 
 // ecdsaKeyHash generates the 4-byte key ID for an ECDSA public key.
 // ECDSA key IDs do not conform to the note standard for other key type
 // (see https://github.com/C2SP/C2SP/blob/8991f70ddf8a11de3a68d5a081e7be27e59d87c8/signed-note.md#signature-types).
-func ecdsaKeyHash(key *ecdsa.PublicKey) (uint32, error) {
+func ecdsaKeyHash(key *ecdsa.PublicKey) (uint32, []byte, error) {
 	marshaled, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling public key: %w", err)
+		return 0, nil, fmt.Errorf("marshaling public key: %w", err)
 	}
 	hash := sha256.Sum256(marshaled)
-	return binary.BigEndian.Uint32(hash[:]), nil
+	return binary.BigEndian.Uint32(hash[:]), hash[:], nil
 }
 
 // rsaKeyhash generates the 4-byte key ID for an RSA public key.
-func rsaKeyHash(name string, key *rsa.PublicKey) (uint32, error) {
+func rsaKeyHash(name string, key *rsa.PublicKey) (uint32, []byte, error) {
 	marshaled, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling public key: %w", err)
+		return 0, nil, fmt.Errorf("marshaling public key: %w", err)
 	}
 	rsaAlg := append([]byte{algUndef}, []byte(rsaID)...)
-	return genConformantKeyHash(name, rsaAlg, marshaled), nil
+	id, hash := genConformantKeyHash(name, rsaAlg, marshaled)
+	return id, hash, nil
 }
 
-// keyHash generates a 4-byte identifier for a public key/origin
-func keyHash(origin string, key crypto.PublicKey) (uint32, error) {
+// KeyHash generates a truncated (4-byte) and non-truncated identifier for a
+// public key/origin
+func KeyHash(origin string, key crypto.PublicKey) (uint32, []byte, error) {
 	var keyID uint32
+	var logID []byte
 	var err error
 
 	switch pk := key.(type) {
 	case *ecdsa.PublicKey:
-		keyID, err = ecdsaKeyHash(pk)
+		keyID, logID, err = ecdsaKeyHash(pk)
 		if err != nil {
-			return 0, fmt.Errorf("getting ECDSA key hash: %w", err)
+			return 0, nil, fmt.Errorf("getting ECDSA key hash: %w", err)
 		}
 	case ed25519.PublicKey:
-		keyID = ed25519KeyHash(origin, pk)
+		keyID, logID = ed25519KeyHash(origin, pk)
 	case *rsa.PublicKey:
-		keyID, err = rsaKeyHash(origin, pk)
+		keyID, logID, err = rsaKeyHash(origin, pk)
 		if err != nil {
-			return 0, fmt.Errorf("getting RSA key hash: %w", err)
+			return 0, nil, fmt.Errorf("getting RSA key hash: %w", err)
 		}
 	default:
-		return 0, fmt.Errorf("unsupported key type: %T", key)
+		return 0, nil, fmt.Errorf("unsupported key type: %T", key)
 	}
 
-	return keyID, nil
+	return keyID, logID, nil
 }
 
 // NewNoteSigner converts a sigstore/sigstore/pkg/signature.Signer into a note.Signer.
@@ -167,7 +171,7 @@ func NewNoteSigner(ctx context.Context, origin string, signer signature.Signer) 
 		return nil, fmt.Errorf("getting public key: %w", err)
 	}
 
-	keyID, err := keyHash(origin, pubKey)
+	keyID, _, err := KeyHash(origin, pubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +197,7 @@ func NewNoteVerifier(origin string, verifier signature.Verifier) (note.Verifier,
 		return nil, fmt.Errorf("getting public key: %w", err)
 	}
 
-	keyID, err := keyHash(origin, pubKey)
+	keyID, _, err := KeyHash(origin, pubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/note/note_test.go
+++ b/pkg/note/note_test.go
@@ -18,6 +18,7 @@ package note
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -82,21 +83,25 @@ func TestKeyHash(t *testing.T) {
 		name          string
 		key           []byte
 		expectedKeyID uint32
+		expectedLogID []byte
 	}{
 		{
 			name:          "ed25519",
 			key:           ed25519PrivKey,
-			expectedKeyID: 3839787747, // echo $((0x$(printf "%s%b%b%s" "testkey" "\x0A" "\x01" "$(openssl pkey -in ed25519-priv-key.pem -pubout -out - | openssl pkey -pubin -in /dev/stdin -outform DER -out - | tail -c32)" | sha256sum | cut -d ' ' -f 1 | head -c 8)))
+			expectedKeyID: 3839787747,                                                                            // echo $((0x$(printf "%s%b%b%s" "testkey" "\x0A" "\x01" "$(openssl pkey -in ed25519-priv-key.pem -pubout -out - | openssl pkey -pubin -in /dev/stdin -outform DER -out - | tail -c32)" | sha256sum | cut -d ' ' -f 1 | head -c 8)))
+			expectedLogID: hexDecodeOrDie(t, "e4de82e34c8c270d87612a3d6a1e297e2cd0ed9cb89ea7aeec8ce4d0b54e6775"), // echo $(printf "%s%b%b%s" "testkey" "\x0A" "\x01" "$(openssl pkey -in ed25519-priv-key.pem -pubout -out - | openssl pkey -pubin -in /dev/stdin -outform DER -out - | tail -c32)" | sha256sum | cut -d ' ' -f 1)
 		},
 		{
 			name:          "ecdsa",
 			key:           ecdsaPrivKey,
-			expectedKeyID: 2408765216, // echo $((0x$(openssl ec -in ec-secp256r1-priv-key.pem -pubout - | openssl ec -pubin -in /dev/stdin -outform DER -out - | sha256sum | cut -d ' ' -f 1 | head -c 8)))
+			expectedKeyID: 2408765216,                                                                            // echo $((0x$(openssl ec -in ec-secp256r1-priv-key.pem -pubout - | openssl ec -pubin -in /dev/stdin -outform DER -out - | sha256sum | cut -d ' ' -f 1 | head -c 8)))
+			expectedLogID: hexDecodeOrDie(t, "8f92d720f56c219e34895a76a636a3353ddbf7813f9fa317e19982eafa945328"), // echo $(openssl ec -in ec-secp256r1-priv-key.pem -pubout - | openssl ec -pubin -in /dev/stdin -outform DER -out - | sha256sum | cut -d ' ' -f 1)
 		},
 		{
 			name:          "rsa",
 			key:           rsaPrivKey,
-			expectedKeyID: 2918460683, // echo $((0x$({ printf "%s%b%b%s" "testkey" "\x0A" "\xFF" 'PKIX-RSA-PKCS#1v1.5' ; openssl rsa -in rsa-priv-key.pem -pubout -out - | openssl rsa -in /dev/stdin -pubin -outform DER -out - ;  } | sha256sum | cut -d ' ' -f 1 | head -c8)))
+			expectedKeyID: 2918460683,                                                                            // echo $((0x$({ printf "%s%b%b%s" "testkey" "\x0A" "\xFF" 'PKIX-RSA-PKCS#1v1.5' ; openssl rsa -in rsa-priv-key.pem -pubout -out - | openssl rsa -in /dev/stdin -pubin -outform DER -out - ;  } | sha256sum | cut -d ' ' -f 1 | head -c8)))
+			expectedLogID: hexDecodeOrDie(t, "adf42d0b4478f2d07e5c8c3e63640a7e41b440c19dc47010c3a4936af75d85b6"), // echo $({ printf "%s%b%b%s" "testkey" "\x0A" "\xFF" 'PKIX-RSA-PKCS#1v1.5' ; openssl rsa -in rsa-priv-key.pem -pubout -out - | openssl rsa -in /dev/stdin -pubin -outform DER -out - ;  } | sha256sum | cut -d ' ' -f 1)
 		},
 	}
 	for _, test := range tests {
@@ -116,7 +121,25 @@ func TestKeyHash(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			pubKey, err := signer.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			keyID, logID, err := KeyHash(origin, pubKey)
+			if err != nil {
+				t.Fatal(err)
+			}
 			assert.Equal(t, test.expectedKeyID, noteSigner.KeyHash())
+			assert.Equal(t, test.expectedKeyID, keyID)
+			assert.Equal(t, test.expectedLogID, logID)
 		})
 	}
+}
+
+func hexDecodeOrDie(t *testing.T, text string) []byte {
+	decoded, err := hex.DecodeString(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
 }

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -37,7 +37,7 @@ func TestNewServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := NewServer(storage, false, algReg)
+	server := NewServer(storage, false, algReg, []byte{1})
 	assert.NoError(t, err)
 	assert.NotNil(t, server.storage)
 	assert.NotNil(t, server.algorithmRegistry)
@@ -185,12 +185,14 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeLw7gX40qy1z7JUhGMAaaDITbV7p
 			if err != nil {
 				t.Fatal(err)
 			}
-			server := NewServer(storage, false, algReg)
+			server := NewServer(storage, false, algReg, []byte{1})
 			gotTle, gotErr := server.CreateEntry(context.Background(), test.req)
 			if test.expectError == nil {
 				assert.NoError(t, gotErr)
 				assert.NotNil(t, gotTle)
+				// Check that the fields set by the service are populated
 				assert.NotNil(t, gotTle.KindVersion)
+				assert.NotNil(t, gotTle.LogId)
 			} else {
 				assert.ErrorContains(t, gotErr, test.expectError.Error())
 			}

--- a/pkg/tessera/tessera_test.go
+++ b/pkg/tessera/tessera_test.go
@@ -27,14 +27,9 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 )
 
-var tileHashHex = "81bfc09c412c04da53a1b0ddb94dce48d6a24e9ea58987f7d45a04e8007fb3ca"
-
 func TestAdd(t *testing.T) {
 	ctx := context.Background()
-	tileHash, err := hex.DecodeString(tileHashHex)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tileHash := hexDecodeOrDie(t, "81bfc09c412c04da53a1b0ddb94dce48d6a24e9ea58987f7d45a04e8007fb3ca")
 	readCheckpoint := func(_ context.Context) ([]byte, error) {
 		<-time.After(5 * time.Millisecond)
 		return []byte(`test.origin
@@ -103,10 +98,7 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 
 func TestReadTile(t *testing.T) {
 	ctx := context.Background()
-	tileHash, err := hex.DecodeString(tileHashHex)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tileHash := hexDecodeOrDie(t, "81bfc09c412c04da53a1b0ddb94dce48d6a24e9ea58987f7d45a04e8007fb3ca")
 	s := storage{
 		readTileFn: func(_ context.Context, level, index uint64, _ uint8) ([]byte, error) {
 			if level != 0 && index != 1 {
@@ -164,4 +156,12 @@ func TestAppendOptions(t *testing.T) {
 	assert.Equal(t, 42*time.Second, ao.CheckpointInterval())
 	assert.Equal(t, uint(42), ao.PushbackMaxOutstanding())
 	_ = WithAntispamOptions(ao, nil) // initializes non-persistent antispam
+}
+
+func hexDecodeOrDie(t *testing.T, text string) []byte {
+	decoded, err := hex.DecodeString(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -28,23 +28,28 @@ import (
 	"fmt"
 	"testing"
 
-	pbdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
-	dsset "github.com/sigstore/rekor-tiles/pkg/types/dsse"
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	pbdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	"github.com/sigstore/rekor-tiles/pkg/client/read"
 	"github.com/sigstore/rekor-tiles/pkg/client/write"
 	pb "github.com/sigstore/rekor-tiles/pkg/generated/protobuf"
+	"github.com/sigstore/rekor-tiles/pkg/note"
 	"github.com/sigstore/rekor-tiles/pkg/tessera"
+	dsset "github.com/sigstore/rekor-tiles/pkg/types/dsse"
+	"github.com/sigstore/rekor-tiles/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/signature"
 	sigdsse "github.com/sigstore/sigstore/pkg/signature/dsse"
 	"github.com/stretchr/testify/assert"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"go.step.sm/crypto/pemutil"
+	signednote "golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -66,6 +71,10 @@ func TestReadWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	noteVerifier, err := note.NewNoteVerifier(defaultRekorHostname, verifier)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// reader client
 	reader, err := read.NewReader(defaultGCSURL, defaultRekorHostname, verifier)
@@ -75,6 +84,12 @@ func TestReadWrite(t *testing.T) {
 
 	// writer client
 	writer, err := write.NewWriter(defaultRekorURL, defaultRekorHostname, verifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// log ID
+	_, logID, err := note.KeyHash(defaultRekorHostname, serverPubKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,8 +118,9 @@ func TestReadWrite(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			_, err = writer.Add(ctx, hr) // We don't need to check the TLE here, the client verifies the inclusion proof for us
+			tle, err := writer.Add(ctx, hr)
 			assert.NoError(t, err)
+			assertHashedRekordTLE(t, tle, initialTreeSize, numNewEntries, logID, noteVerifier, hr)
 			return nil
 		})
 	}
@@ -117,8 +133,9 @@ func TestReadWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = writer.Add(ctx, hr)
+	tle, err := writer.Add(ctx, hr)
 	assert.NoError(t, err)
+	assertHashedRekordTLE(t, tle, initialTreeSize, numNewEntries, logID, noteVerifier, hr)
 
 	// Check the checkpoint again
 	checkpoint, note, err = reader.ReadCheckpoint(ctx)
@@ -165,12 +182,14 @@ func TestReadWrite(t *testing.T) {
 	assert.NotNil(t, hrEntry)
 
 	// Add a DSSE entry
+	numNewEntries++
 	dr, err := newDSSERequest(clientPrivKey, clientPubKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tle, err := writer.Add(ctx, dr)
+	tle, err = writer.Add(ctx, dr)
 	assert.NoError(t, err)
+	assertDSSETLE(t, tle, initialTreeSize+numNewEntries-1, logID, noteVerifier, dr)
 
 	safeLogSize, err := tessera.NewSafeInt64(tle.InclusionProof.TreeSize)
 	if err != nil {
@@ -312,4 +331,96 @@ func newDSSERequest(privKey *ecdsa.PrivateKey, pubKey []byte) (*pb.DSSERequestV0
 			},
 		},
 	}, nil
+}
+
+func assertHashedRekordTLE(t *testing.T, tle *pbs.TransparencyLogEntry, initialTreeSize, numNewEntries uint64, logID []byte, verifier signednote.Verifier, hr *pb.HashedRekordRequestV0_0_2) {
+	assert.NotNil(t, tle)
+
+	// Check server does not set deprecated fields
+	assert.Zero(t, tle.IntegratedTime)
+	assert.Nil(t, tle.InclusionPromise)
+
+	// Check populated fields
+	// Assert log index is [initialTreeSize, initialTreeSize+numNewEntries). We can't know the precise index since
+	// entry upload is done in parallel.
+	assert.GreaterOrEqual(t, tle.LogIndex, int64(initialTreeSize))
+	assert.Less(t, tle.LogIndex, int64(initialTreeSize+numNewEntries))
+	// Assert log IDs are equivalent
+	assert.Equal(t, tle.LogId.KeyId, logID)
+	// Assert kind and version match expected values
+	assert.Equal(t, tle.KindVersion.Kind, "hashedrekord")
+	assert.Equal(t, tle.KindVersion.Version, "0.0.2")
+	// Verify checkpoint and inclusion proof
+	verifyInclusionProof(t, tle, verifier)
+	// Parse canonicalized body and assert entry matches request
+	e := &pb.Entry{}
+	assert.NotNil(t, tle.CanonicalizedBody)
+	err := protojson.Unmarshal(tle.CanonicalizedBody, e)
+	assert.NoError(t, err)
+	assert.Equal(t, "hashedrekord", e.Kind)
+	assert.Equal(t, "0.0.2", e.ApiVersion)
+	hrEntry := e.Spec.GetHashedRekordV0_0_2()
+	assert.NotNil(t, hrEntry)
+	assert.Equal(t, hrEntry.Signature, hr.Signature)
+	assert.Equal(t, hrEntry.Data.Algorithm, v1.HashAlgorithm_SHA2_256)
+	assert.Equal(t, hrEntry.Data.Digest, hr.Digest)
+}
+
+func assertDSSETLE(t *testing.T, tle *pbs.TransparencyLogEntry, index uint64, logID []byte, verifier signednote.Verifier, dr *pb.DSSERequestV0_0_2) {
+	assert.NotNil(t, tle)
+
+	// Check server does not set deprecated fields
+	assert.Zero(t, tle.IntegratedTime)
+	assert.Nil(t, tle.InclusionPromise)
+
+	// Check populated fields
+	// Assert log index. There is a single DSSE upload so the exact index is known
+	assert.Equal(t, tle.LogIndex, int64(index))
+	// Assert log IDs are equivalent
+	assert.Equal(t, tle.LogId.KeyId, logID)
+	// Assert kind and version match expected values
+	assert.Equal(t, tle.KindVersion.Kind, "dsse")
+	assert.Equal(t, tle.KindVersion.Version, "0.0.2")
+	// Verify checkpoint and inclusion proof
+	verifyInclusionProof(t, tle, verifier)
+	// Parse canonicalized body and assert entry matches request
+	e := &pb.Entry{}
+	assert.NotNil(t, tle.CanonicalizedBody)
+	err := protojson.Unmarshal(tle.CanonicalizedBody, e)
+	assert.NoError(t, err)
+	assert.Equal(t, "dsse", e.Kind)
+	assert.Equal(t, "0.0.2", e.ApiVersion)
+	dsseEntry := e.Spec.GetDsseV0_0_2()
+	assert.NotNil(t, dsseEntry)
+	// Assert payload hash is as expected
+	assert.Equal(t, dsseEntry.PayloadHash.Algorithm, v1.HashAlgorithm_SHA2_256)
+	expectedPayloadHash := sha256.Sum256(dr.Envelope.Payload)
+	assert.Equal(t, dsseEntry.PayloadHash.Digest, expectedPayloadHash[:])
+	// Assert signature matches envelope's signature
+	assert.Len(t, dsseEntry.Signatures, 1)
+	assert.Equal(t, dsseEntry.Signatures[0].Content, dr.Envelope.Signatures[0].Sig)
+	assert.Equal(t, dsseEntry.Signatures[0].Verifier, dr.Verifiers[0])
+}
+
+func verifyInclusionProof(t *testing.T, tle *pbs.TransparencyLogEntry, verifier signednote.Verifier) {
+	// Server also verifies inclusion proof before returning response
+	assert.NotNil(t, tle.InclusionProof)
+
+	// Verify checkpoint signature
+	checkpoint, err := verify.VerifyCheckpoint(tle.InclusionProof.Checkpoint.Envelope, verifier)
+	assert.NoError(t, err)
+
+	// Verify duplicated tle.inclusion_proof fields match bundle and parsed checkpoint values
+	assert.Equal(t, tle.InclusionProof.LogIndex, tle.LogIndex)
+	assert.Equal(t, tle.InclusionProof.TreeSize, int64(checkpoint.Size))
+	assert.Equal(t, tle.InclusionProof.RootHash, checkpoint.Hash)
+
+	// Verify inclusion proof
+	leafHash := rfc6962.DefaultHasher.HashLeaf(tle.CanonicalizedBody)
+	assert.NoError(t, proof.VerifyInclusion(rfc6962.DefaultHasher,
+		uint64(tle.LogIndex),
+		checkpoint.Size,
+		leafHash,
+		tle.InclusionProof.Hashes,
+		checkpoint.Hash))
 }


### PR DESCRIPTION
Fixes #285

To minimize the transition for clients between Rekor v1 and v2, we will
include the log ID in the response. This log ID is used by clients to
look up the correct instance in a trust root, though some clients ignore
it and build a pool of verification keys instead, and compare a
truncated log ID to the checkpoint signature key prefix.

I've chosen to make the log ID equal to the non-truncated checkpoint key
ID. For clients that treat the log ID as an opaque string when looking
up the instance in the trusted root, no changes should be needed.
Similarly, if a client uses the log ID to compare against the checkpoint
key ID, like what sigstore-python does, no changes are needed.

In the TransparencyLogInstance in the trusted root, both the log ID and
checkpoint key ID will be set to the same value. Longer-term, we'll
deprecate log ID. Even longer-term, ideally clients would enumerate all
keys and compute the checkpoint key IDs themselves, but for now, we'll
keep populating the IDs in the trusted root for convenience.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
