### PR TITLE
Return 501 Method Not Implemented for read APIs

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -209,6 +209,30 @@ func TestReadWrite(t *testing.T) {
 	assert.ErrorContains(t, err, fmt.Sprintf("an equivalent entry already exists in the transparency log with index %d", oldIndex))
 }
 
+func TestUnimplementedReadMethods(t *testing.T) {
+	ctx := context.Background()
+
+	serverPubKey, err := pemutil.Read(defaultServerPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := signature.LoadDefaultVerifier(serverPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := read.NewReader(defaultRekorURL+"/api/v2", defaultRekorHostname, verifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = reader.ReadCheckpoint(ctx)
+	assert.ErrorContains(t, err, "501") // the reader client drops the request body, hence why we only check the status code
+	_, err = reader.ReadTile(ctx, 0, 0, 0)
+	assert.ErrorContains(t, err, "501")
+	_, err = reader.ReadEntryBundle(ctx, 0, 0)
+	assert.ErrorContains(t, err, "501")
+}
+
 func artifactDigest(idx uint64) []byte {
 	baseArtifact := "testartifact"
 	artifact := []byte(fmt.Sprintf("%s%d", baseArtifact, idx))


### PR DESCRIPTION
When we were deploying the service to staging, we noticed that the read APIs were returning 200 with an empty body for some reason. The root cause is due to how we handle returning an Unimplemented gRPC status code.

In order to return the non-retryable 405 Method Not Allowed when the server goes into a read-only mode, we added special handling when the gRPC status code is set to Unimplemented. Otherwise, it returns a 501 Not Implemented, which is not an accurate status for when the server is read-only.

When the status code is Unimplemented, we set the response code and body in the httpResponseModifier function based on internally-set gRPC headers. This worked correctly for the read-only response. However, for the 3 unimplemented read APIs, while we were setting a gRPC response code of Unimplemented, we weren't setting the internal headers. This meant that we skipped over where the HTTP response code/body is set, and so we returned a default 200 with an empty body for the read APIs.

This PR modifies the HTTP error code handler to look for a custom header rather than a specific gRPC error code, so that when the gRPC code is Unimplemented without a custom header, it returns 501.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
