### PR TITLE
Fix root hash as bytes rather than hex-encoded

### DIFF
--- a/pkg/tessera/tessera.go
+++ b/pkg/tessera/tessera.go
@@ -17,7 +17,6 @@ package tessera
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"time"
@@ -214,7 +213,7 @@ func (s *storage) buildProof(ctx context.Context, idx *SafeInt64, signedCheckpoi
 	}
 	return &rekor_pb.InclusionProof{
 		LogIndex: idx.I(),
-		RootHash: []byte(hex.EncodeToString(checkpoint.Hash)),
+		RootHash: checkpoint.Hash,
 		TreeSize: safeCheckpointSize.I(),
 		Hashes:   inclusionProof,
 		Checkpoint: &rekor_pb.Checkpoint{


### PR DESCRIPTION
To produce strings in Rekor v1 responses, all hashes were hex-encoded. When the protobuf specs were created, rather than specify strings for hashes, we specified bytes. This fixes the root hash of the inclusion proof to be a byte array (and when marshalled to JSON, it will be base64-encoded).

This is another example of what should be updated with a TLE v2, dropping log index (specified in the bundle), root hash and tree size (both specified in the checkpoint). I'll update the client spec to recommend ignoring these fields.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
