### PR TITLE
fix pydantic generation

### DIFF
--- a/protoc-builder/Makefile
+++ b/protoc-builder/Makefile
@@ -59,7 +59,7 @@ python: Dockerfile.python protoc-python-image
 	@mkdir -p ${PROJECT_DIR}/${CLIENTS_OUT}/python
 	${DOCKER_RUN} -v ${PROJECT_DIR}:${MOUNT_POINT} ${PROTOC_PYTHON_IMAGE} \
 		-I/opt/include -I/googleapis -I/protobuf-specs -I${MOUNT_POINT}/api/proto \
-    --python_betterproto_opt=pydantic_dataclass \
+    --python_betterproto_opt=pydantic_dataclasses \
 	  --python_betterproto_out=${MOUNT_POINT}/${CLIENTS_OUT}/python \
     ${PROTOS}
 

--- a/protoc-builder/python-requirements.txt
+++ b/protoc-builder/python-requirements.txt
@@ -1,2 +1,3 @@
 betterproto[compiler]==2.0.0b7
 mypy-protobuf==3.6.0
+pydantic==2.11.0


### PR DESCRIPTION
https://github.com/sigstore/rekor-tiles/issues/289

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Followup to #303 



#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fixes the option for specifying pydantic types.

 - https://github.com/danielgtaylor/python-betterproto/blob/124613f55fa8ff62a460e1ad33c5c78723b703a0/README.md#generating-pydantic-models

> With the important change being --python_betterproto_opt=pydantic_dataclasses. This will swap the dataclass implementation from the builtin python dataclass to the pydantic dataclass. You must have pydantic as a dependency in your project for this to work.

### Testing

The existing code doesn't produce an error, but here's a sample of the different results with the new change

```python
-from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Fix pydantic typing in the python code generator.
