### PR TITLE
Split TLS flags into separate gRPC and HTTP flags

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -161,15 +161,16 @@ var serveCmd = &cobra.Command{
 				server.WithHTTPTimeout(viper.GetDuration("timeout")),
 				server.WithHTTPMaxRequestBodySize(viper.GetInt("max-request-body-size")),
 				server.WithHTTPMetricsPort(viper.GetInt("http-metrics-port")),
-				server.WithHTTPTLSCredentials(viper.GetString("tls-cert-file"), viper.GetString("tls-key-file")),
+				server.WithHTTPTLSCredentials(viper.GetString("http-tls-cert-file"), viper.GetString("http-tls-key-file")),
+				server.WithGRPCTLSCredentials(viper.GetString("grpc-tls-cert-file")),
 			),
 			server.NewGRPCConfig(
 				server.WithGRPCPort(viper.GetInt("grpc-port")),
 				server.WithGRPCHost(viper.GetString("grpc-address")),
 				server.WithGRPCTimeout(viper.GetDuration("timeout")),
 				server.WithGRPCMaxMessageSize(viper.GetInt("max-request-body-size")),
-				server.WithTLSCredentials(viper.GetString("tls-cert-file"), viper.GetString("tls-key-file")),
 				server.WithGRPCLogLevel(logLevel, viper.GetBool("request-response-logging")),
+				server.WithTLSCredentials(viper.GetString("grpc-tls-cert-file"), viper.GetString("grpc-tls-key-file")),
 			),
 			rekorServer,
 			shutdownFn,
@@ -189,6 +190,10 @@ func init() {
 	serveCmd.Flags().Int("max-request-body-size", 4*1024*1024, "maximum request body size in bytes")
 	serveCmd.Flags().String("log-level", "info", "log level for the process. options are [debug, info, warn, error]")
 	serveCmd.Flags().Bool("request-response-logging", false, "enables logging of request and response content; log-level must be 'debug' for this to take effect")
+	serveCmd.Flags().String("grpc-tls-cert-file", "", "optional TLS certificate for serving gRPC over TLS")
+	serveCmd.Flags().String("grpc-tls-key-file", "", "optional TLS private key for serving gRPC over TLS")
+	serveCmd.Flags().String("http-tls-cert-file", "", "optional TLS certificate for serving HTTP over TLS")
+	serveCmd.Flags().String("http-tls-key-file", "", "optional TLS private key for serving HTTP over TLS")
 
 	// hostname
 	hostname, err := os.Hostname()

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -67,10 +67,10 @@ func newHTTPProxy(ctx context.Context, config *HTTPConfig, grpcServer *grpcServe
 	}
 
 	var opts []grpc.DialOption
-	if config.HasTLS() {
-		creds, err := credentials.NewClientTLSFromFile(config.certFile, "")
+	if config.HasGRPCTLS() {
+		creds, err := credentials.NewClientTLSFromFile(config.grpcCertFile, "")
 		if err != nil {
-			slog.Error("failed to create TLS credentials", "errors", err)
+			slog.Error("failed to create gRPC TLS credentials", "errors", err)
 			os.Exit(1)
 		}
 		opts = []grpc.DialOption{grpc.WithTransportCredentials(creds)}

--- a/pkg/server/httpconfig.go
+++ b/pkg/server/httpconfig.go
@@ -27,6 +27,7 @@ type HTTPConfig struct {
 	maxRequestBodySize int
 	certFile           string
 	keyFile            string
+	grpcCertFile       string
 }
 type HTTPOption func(config *HTTPConfig)
 
@@ -90,5 +91,15 @@ func WithHTTPTLSCredentials(certFile, keyFile string) HTTPOption {
 	return func(config *HTTPConfig) {
 		config.certFile = certFile
 		config.keyFile = keyFile
+	}
+}
+
+func (hc HTTPConfig) HasGRPCTLS() bool {
+	return hc.grpcCertFile != ""
+}
+
+func WithGRPCTLSCredentials(certFile string) HTTPOption {
+	return func(config *HTTPConfig) {
+		config.grpcCertFile = certFile
 	}
 }

--- a/pkg/server/httpconfig_test.go
+++ b/pkg/server/httpconfig_test.go
@@ -23,60 +23,60 @@ func TestNewHTTPConfig(t *testing.T) {
 	// Test default configuration
 	config := NewHTTPConfig()
 	if config.host != "localhost" {
-		t.Errorf("Expected host to be localhost, got %s", config.host)
+		t.Errorf("expected host to be localhost, got %s", config.host)
 	}
 	if config.timeout != 60*time.Second {
-		t.Errorf("Expected idleTimeout to be 60s, got %v", config.timeout)
+		t.Errorf("expected idleTimeout to be 60s, got %v", config.timeout)
 	}
 	if config.maxRequestBodySize != 4*1024*1024 {
-		t.Errorf("Expected maxSize)} to be 4MB, got %d", config.maxRequestBodySize)
+		t.Errorf("expected maxSize)} to be 4MB, got %d", config.maxRequestBodySize)
 	}
 	if config.port != 8080 {
-		t.Errorf("Expected port to be 8080, got %d", config.port)
+		t.Errorf("expected port to be 8080, got %d", config.port)
 	}
 	if config.metricsPort != 2112 {
-		t.Errorf("Expected metricsport to be 2112, got %d", config.port)
+		t.Errorf("expected metricsport to be 2112, got %d", config.port)
 	}
 	if config.HTTPTarget() != "localhost:8080" {
-		t.Errorf("Expected http target to be localhost:8080, got %s", config.HTTPTarget())
+		t.Errorf("expected http target to be localhost:8080, got %s", config.HTTPTarget())
 	}
 	if config.HTTPMetricsTarget() != "localhost:2112" {
-		t.Errorf("Expected http metrics target to be localhost:2112, got %s", config.HTTPTarget())
+		t.Errorf("expected http metrics target to be localhost:2112, got %s", config.HTTPTarget())
 	}
 }
 
 func TestWithHTTPPort(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPPort(9000))
 	if config.port != 9000 {
-		t.Errorf("Expected port to be 9000, got %d", config.port)
+		t.Errorf("expected port to be 9000, got %d", config.port)
 	}
 }
 
 func TestWithHTTPHost(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPHost("example.com"))
 	if config.host != "example.com" {
-		t.Errorf("Expected host to be example.com, got %s", config.host)
+		t.Errorf("expected host to be example.com, got %s", config.host)
 	}
 }
 
 func TestWithHTTTimeout(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPTimeout(30 * time.Second))
 	if config.timeout != 30*time.Second {
-		t.Errorf("Expected idleTimeout to be 30s, got %v", config.timeout)
+		t.Errorf("expected idleTimeout to be 30s, got %v", config.timeout)
 	}
 }
 
 func TestWithHTTPMaxRequestBodySize(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPMaxRequestBodySize(2 * 1024 * 1024))
 	if config.maxRequestBodySize != 2*1024*1024 {
-		t.Errorf("Expected maxSize to be) 2MB, got %d", config.maxRequestBodySize)
+		t.Errorf("expected maxSize to be) 2MB, got %d", config.maxRequestBodySize)
 	}
 }
 
 func TestWithHTTPMetricsPort(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPMetricsPort(9001))
 	if config.metricsPort != 9001 {
-		t.Errorf("Expected metrics port to be 9001, got %d", config.port)
+		t.Errorf("expected metrics port to be 9001, got %d", config.port)
 	}
 }
 
@@ -89,58 +89,73 @@ func TestMultipleOptions(t *testing.T) {
 		WithHTTPMetricsPort(9091),
 	)
 	if config.port != 9090 {
-		t.Errorf("Expected port to be 9090, got %d", config.port)
+		t.Errorf("expected port to be 9090, got %d", config.port)
 	}
 	if config.metricsPort != 9091 {
-		t.Errorf("Expected port to be 9091, got %d", config.port)
+		t.Errorf("expected port to be 9091, got %d", config.port)
 	}
 	if config.host != "test.example.com" {
-		t.Errorf("Expected host to be test.example.com, got %s", config.host)
+		t.Errorf("expected host to be test.example.com, got %s", config.host)
 	}
 	if config.timeout != 10*time.Second {
-		t.Errorf("Expected idleTimeout to be 10s, got %v", config.timeout)
+		t.Errorf("expected idleTimeout to be 10s, got %v", config.timeout)
 	}
 	if config.maxRequestBodySize != 1*1024*1024 {
-		t.Errorf("Expected maxSize to be 1MB, got %d", config.maxRequestBodySize)
+		t.Errorf("expected maxSize to be 1MB, got %d", config.maxRequestBodySize)
 	}
 	if config.HTTPTarget() != "test.example.com:9090" {
-		t.Errorf("Expected http target to be test.example.com:9090, got %s", config.HTTPTarget())
+		t.Errorf("expected http target to be test.example.com:9090, got %s", config.HTTPTarget())
 	}
 	if config.HTTPMetricsTarget() != "test.example.com:9091" {
-		t.Errorf("Expected http metrics target to be test.example.com:9091, got %s", config.HTTPTarget())
+		t.Errorf("expected http metrics target to be test.example.com:9091, got %s", config.HTTPTarget())
 	}
 }
 func TestWithHTTPTLSCredentials(t *testing.T) {
 	config := NewHTTPConfig(WithHTTPTLSCredentials("cert.pem", "key.pem"))
 	if config.certFile != "cert.pem" {
-		t.Errorf("Expected certFile to be cert.pem, got %s", config.certFile)
+		t.Errorf("expected certFile to be cert.pem, got %s", config.certFile)
 	}
 	if config.keyFile != "key.pem" {
-		t.Errorf("Expected keyFile to be key.pem, got %s", config.keyFile)
+		t.Errorf("expected keyFile to be key.pem, got %s", config.keyFile)
 	}
 	if !config.HasTLS() {
-		t.Error("Expected HasTLS to return true when TLS credentials are set")
+		t.Error("expected HasTLS to return true when TLS credentials are set")
 	}
 }
 
 func TestHasTLS(t *testing.T) {
 	config := NewHTTPConfig()
 	if config.HasTLS() {
-		t.Error("Expected HasTLS to return false when no TLS credentials are set")
+		t.Error("expected HasTLS to return false when no TLS credentials are set")
 	}
 
 	config = NewHTTPConfig(func(c *HTTPConfig) { c.certFile = "cert.pem" })
 	if config.HasTLS() {
-		t.Error("Expected HasTLS to return false when only certFile is set")
+		t.Error("expected HasTLS to return false when only certFile is set")
 	}
 
 	config = NewHTTPConfig(func(c *HTTPConfig) { c.keyFile = "key.pem" })
 	if config.HasTLS() {
-		t.Error("Expected HasTLS to return false when only keyFile is set")
+		t.Error("expected HasTLS to return false when only keyFile is set")
 	}
 
 	config = NewHTTPConfig(WithHTTPTLSCredentials("cert.pem", "key.pem"))
 	if !config.HasTLS() {
-		t.Error("Expected HasTLS to return true when both certFile and keyFile are set")
+		t.Error("expected HasTLS to return true when both certFile and keyFile are set")
+	}
+}
+
+func TestWithGRPCTLSCredentials(t *testing.T) {
+	config := NewHTTPConfig()
+	if config.HasGRPCTLS() {
+		t.Error("expected HasGRPCTLS to return false when no gRPC TLS credentials are set")
+	}
+
+	config = NewHTTPConfig(WithGRPCTLSCredentials("cert.pem"))
+	if config.grpcCertFile != "cert.pem" {
+		t.Errorf("expected gRPC cert file to be cert.pem, got %s", config.certFile)
+	}
+	if !config.HasGRPCTLS() {
+		t.Error("expected HasGRPCTLS to return true when both certFile and keyFile are set")
 	}
 }

--- a/pkg/server/service_mock.go
+++ b/pkg/server/service_mock.go
@@ -107,6 +107,7 @@ func (ms *MockServer) StartTLS(t *testing.T) {
 		WithHTTPHost("localhost"),
 		WithHTTPPort(8080),
 		WithHTTPTLSCredentials(certFile, keyFile),
+		WithGRPCTLSCredentials(certFile),
 	)
 
 	s := &mockRekorServer{}


### PR DESCRIPTION
GCP requires that when the front load balancer is HTTPS and the request is over gRPC, then the connection between the load balancer and service backend must be over TLS as well. This is not true for HTTP traffic, where the front load balancer can be HTTPS but the connection between the load balancer and service backend can be over HTTP.

This PR splits the TLS flags into separate gRPC and HTTP flags so that deployers can selectively enable TLS for each serving path. Also this PR declares the flags, which previously were not declared.

There are existing tests that TLS works as expected. Updating the service mock to use the gRPC credentials makes the TLS tests pass.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
