### PR TITLE
Remove json_name from proto message fields

### DIFF
--- a/api/proto/entry.proto
+++ b/api/proto/entry.proto
@@ -30,23 +30,14 @@ option go_package = "github.com/sigstore/rekor-tiles/pkg/generated/protobuf";
 // and Rekor v2 (a typed proto defintion).
 message Entry {
     string kind = 1 [(google.api.field_behavior) = REQUIRED];
-    string api_version = 2 [
-        (google.api.field_behavior) = REQUIRED,
-        json_name = "apiVersion"
-    ];
+    string api_version = 2 [(google.api.field_behavior) = REQUIRED];
     Spec spec = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Spec contains one of the Rekor entry types.
 message Spec {
     oneof spec {
-        HashedRekordLogEntryV0_0_2 hashed_rekord_v0_0_2 = 1 [
-            (google.api.field_behavior) = REQUIRED,
-            json_name = "hashedRekordV0_0_2"
-        ];
-        DSSELogEntryV0_0_2 dsse_v0_0_2  = 2 [
-            (google.api.field_behavior) = REQUIRED,
-            json_name = "dsseV0_0_2"
-        ];
+        HashedRekordLogEntryV0_0_2 hashed_rekord_v0_0_2 = 1 [(google.api.field_behavior) = REQUIRED];
+        DSSELogEntryV0_0_2 dsse_v0_0_2  = 2 [(google.api.field_behavior) = REQUIRED];
     }
 }

--- a/api/proto/rekor_service.proto
+++ b/api/proto/rekor_service.proto
@@ -61,14 +61,8 @@ service Rekor {
 // Create a new HashedRekord or DSSE
 message CreateEntryRequest {
     oneof spec {
-        HashedRekordRequestV0_0_2 hashed_rekord_request_v0_0_2 = 1 [
-            (google.api.field_behavior) = REQUIRED,
-            json_name = "hashedRekordRequestV0_0_2"
-        ];
-        DSSERequestV0_0_2 dsse_request_v0_0_2  = 2 [
-            (google.api.field_behavior) = REQUIRED,
-            json_name = "dsseRequestV0_0_2"
-        ];
+        HashedRekordRequestV0_0_2 hashed_rekord_request_v0_0_2 = 1 [(google.api.field_behavior) = REQUIRED];
+        DSSERequestV0_0_2 dsse_request_v0_0_2  = 2 [(google.api.field_behavior) = REQUIRED];
     }
 }
 

--- a/docs/openapi/rekor_service.swagger.json
+++ b/docs/openapi/rekor_service.swagger.json
@@ -453,17 +453,17 @@
     "v2CreateEntryRequest": {
       "type": "object",
       "properties": {
-        "hashedRekordRequestV0_0_2": {
+        "hashedRekordRequestV002": {
           "$ref": "#/definitions/v2HashedRekordRequestV0_0_2"
         },
-        "dsseRequestV0_0_2": {
+        "dsseRequestV002": {
           "$ref": "#/definitions/v2DSSERequestV0_0_2"
         }
       },
       "title": "Create a new HashedRekord or DSSE",
       "required": [
-        "hashedRekordRequestV0_0_2",
-        "dsseRequestV0_0_2"
+        "hashedRekordRequestV002",
+        "dsseRequestV002"
       ]
     },
     "v2DSSERequestV0_0_2": {

--- a/pkg/generated/protobuf/entry.pb.go
+++ b/pkg/generated/protobuf/entry.pb.go
@@ -174,11 +174,11 @@ type isSpec_Spec interface {
 }
 
 type Spec_HashedRekordV0_0_2 struct {
-	HashedRekordV0_0_2 *HashedRekordLogEntryV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_v0_0_2,json=hashedRekordV0_0_2,proto3,oneof"`
+	HashedRekordV0_0_2 *HashedRekordLogEntryV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_v0_0_2,json=hashedRekordV002,proto3,oneof"`
 }
 
 type Spec_DsseV0_0_2 struct {
-	DsseV0_0_2 *DSSELogEntryV0_0_2 `protobuf:"bytes,2,opt,name=dsse_v0_0_2,json=dsseV0_0_2,proto3,oneof"`
+	DsseV0_0_2 *DSSELogEntryV0_0_2 `protobuf:"bytes,2,opt,name=dsse_v0_0_2,json=dsseV002,proto3,oneof"`
 }
 
 func (*Spec_HashedRekordV0_0_2) isSpec_Spec() {}
@@ -195,11 +195,10 @@ const file_entry_proto_rawDesc = "" +
 	"\x04kind\x18\x01 \x01(\tB\x03\xe0A\x02R\x04kind\x12$\n" +
 	"\vapi_version\x18\x02 \x01(\tB\x03\xe0A\x02R\n" +
 	"apiVersion\x124\n" +
-	"\x04spec\x18\x03 \x01(\v2\x1b.dev.sigstore.rekor.v2.SpecB\x03\xe0A\x02R\x04spec\"\xcd\x01\n" +
-	"\x04Spec\x12j\n" +
-	"\x14hashed_rekord_v0_0_2\x18\x01 \x01(\v21.dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2B\x03\xe0A\x02H\x00R\x12hashedRekordV0_0_2\x12Q\n" +
-	"\vdsse_v0_0_2\x18\x02 \x01(\v2).dev.sigstore.rekor.v2.DSSELogEntryV0_0_2B\x03\xe0A\x02H\x00R\n" +
-	"dsseV0_0_2B\x06\n" +
+	"\x04spec\x18\x03 \x01(\v2\x1b.dev.sigstore.rekor.v2.SpecB\x03\xe0A\x02R\x04spec\"\xc9\x01\n" +
+	"\x04Spec\x12h\n" +
+	"\x14hashed_rekord_v0_0_2\x18\x01 \x01(\v21.dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2B\x03\xe0A\x02H\x00R\x10hashedRekordV002\x12O\n" +
+	"\vdsse_v0_0_2\x18\x02 \x01(\v2).dev.sigstore.rekor.v2.DSSELogEntryV0_0_2B\x03\xe0A\x02H\x00R\bdsseV002B\x06\n" +
 	"\x04specB8Z6github.com/sigstore/rekor-tiles/pkg/generated/protobufb\x06proto3"
 
 var (

--- a/pkg/generated/protobuf/rekor_service.pb.go
+++ b/pkg/generated/protobuf/rekor_service.pb.go
@@ -111,11 +111,11 @@ type isCreateEntryRequest_Spec interface {
 }
 
 type CreateEntryRequest_HashedRekordRequestV0_0_2 struct {
-	HashedRekordRequestV0_0_2 *HashedRekordRequestV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_request_v0_0_2,json=hashedRekordRequestV0_0_2,proto3,oneof"`
+	HashedRekordRequestV0_0_2 *HashedRekordRequestV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_request_v0_0_2,json=hashedRekordRequestV002,proto3,oneof"`
 }
 
 type CreateEntryRequest_DsseRequestV0_0_2 struct {
-	DsseRequestV0_0_2 *DSSERequestV0_0_2 `protobuf:"bytes,2,opt,name=dsse_request_v0_0_2,json=dsseRequestV0_0_2,proto3,oneof"`
+	DsseRequestV0_0_2 *DSSERequestV0_0_2 `protobuf:"bytes,2,opt,name=dsse_request_v0_0_2,json=dsseRequestV002,proto3,oneof"`
 }
 
 func (*CreateEntryRequest_HashedRekordRequestV0_0_2) isCreateEntryRequest_Spec() {}
@@ -229,10 +229,10 @@ var File_rekor_service_proto protoreflect.FileDescriptor
 const file_rekor_service_proto_rawDesc = "" +
 	"\n" +
 	"\x13rekor_service.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x19google/api/httpbody.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x14sigstore_rekor.proto\x1a\x12hashedrekord.proto\x1a\n" +
-	"dsse.proto\"\xf7\x01\n" +
-	"\x12CreateEntryRequest\x12x\n" +
-	"\x1chashed_rekord_request_v0_0_2\x18\x01 \x01(\v20.dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2B\x03\xe0A\x02H\x00R\x19hashedRekordRequestV0_0_2\x12_\n" +
-	"\x13dsse_request_v0_0_2\x18\x02 \x01(\v2(.dev.sigstore.rekor.v2.DSSERequestV0_0_2B\x03\xe0A\x02H\x00R\x11dsseRequestV0_0_2B\x06\n" +
+	"dsse.proto\"\xf3\x01\n" +
+	"\x12CreateEntryRequest\x12v\n" +
+	"\x1chashed_rekord_request_v0_0_2\x18\x01 \x01(\v20.dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2B\x03\xe0A\x02H\x00R\x17hashedRekordRequestV002\x12]\n" +
+	"\x13dsse_request_v0_0_2\x18\x02 \x01(\v2(.dev.sigstore.rekor.v2.DSSERequestV0_0_2B\x03\xe0A\x02H\x00R\x0fdsseRequestV002B\x06\n" +
 	"\x04spec\")\n" +
 	"\vTileRequest\x12\f\n" +
 	"\x01L\x18\x01 \x01(\rR\x01L\x12\f\n" +


### PR DESCRIPTION
#### Summary
this is causing complications is some json converters (betterproto?) so lets just keep it simple.

#### Release Note

#### Documentation
