### PR TITLE
Change embedded version naming on proto types

### DIFF
--- a/api/proto/dsse.proto
+++ b/api/proto/dsse.proto
@@ -23,8 +23,8 @@ import "verifier.proto";
 
 option go_package = "github.com/sigstore/rekor-tiles/pkg/generated/protobuf";
 
-// A request to add a DSSE entry to the log
-message DSSERequestV0_0_2 {
+// A request to add a DSSE v0.0.2 entry to the log
+message DSSERequestV002 {
     // A DSSE envelope
     io.intoto.Envelope envelope = 1 [(google.api.field_behavior) = REQUIRED];
     // All necessary verification material to verify all signatures embedded in the envelope
@@ -32,7 +32,7 @@ message DSSERequestV0_0_2 {
 }
 
 
-message DSSELogEntryV0_0_2 {
+message DSSELogEntryV002 {
     // The hash of the DSSE payload
     dev.sigstore.common.v1.HashOutput payloadHash = 1 [(google.api.field_behavior) = REQUIRED];
     // Signatures and their associated verification material used to verify the payload

--- a/api/proto/entry.proto
+++ b/api/proto/entry.proto
@@ -37,7 +37,7 @@ message Entry {
 // Spec contains one of the Rekor entry types.
 message Spec {
     oneof spec {
-        HashedRekordLogEntryV0_0_2 hashed_rekord_v0_0_2 = 1 [(google.api.field_behavior) = REQUIRED];
-        DSSELogEntryV0_0_2 dsse_v0_0_2  = 2 [(google.api.field_behavior) = REQUIRED];
+        HashedRekordLogEntryV002 hashed_rekord_v002 = 1 [(google.api.field_behavior) = REQUIRED];
+        DSSELogEntryV002 dsse_v002  = 2 [(google.api.field_behavior) = REQUIRED];
     }
 }

--- a/api/proto/hashedrekord.proto
+++ b/api/proto/hashedrekord.proto
@@ -22,15 +22,15 @@ import "verifier.proto";
 
 option go_package = "github.com/sigstore/rekor-tiles/pkg/generated/protobuf";
 
-// A request to add a hashedrekord to the log
-message HashedRekordRequestV0_0_2 {
+// A request to add a hashedrekord v0.0.2 to the log
+message HashedRekordRequestV002 {
     // The hashed data
     bytes digest = 1 [(google.api.field_behavior) = REQUIRED];
     // A single signature over the hashed data with the verifier needed to validate it
     Signature signature = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-message HashedRekordLogEntryV0_0_2 {
+message HashedRekordLogEntryV002 {
     // The hashed data
     dev.sigstore.common.v1.HashOutput data = 1 [(google.api.field_behavior) = REQUIRED];
     // A single signature over the hashed data with the verifier needed to validate it

--- a/api/proto/rekor_service.proto
+++ b/api/proto/rekor_service.proto
@@ -61,8 +61,8 @@ service Rekor {
 // Create a new HashedRekord or DSSE
 message CreateEntryRequest {
     oneof spec {
-        HashedRekordRequestV0_0_2 hashed_rekord_request_v0_0_2 = 1 [(google.api.field_behavior) = REQUIRED];
-        DSSERequestV0_0_2 dsse_request_v0_0_2  = 2 [(google.api.field_behavior) = REQUIRED];
+        HashedRekordRequestV002 hashed_rekord_request_v002 = 1 [(google.api.field_behavior) = REQUIRED];
+        DSSERequestV002 dsse_request_v002 = 2 [(google.api.field_behavior) = REQUIRED];
     }
 }
 

--- a/docs/openapi/rekor_service.swagger.json
+++ b/docs/openapi/rekor_service.swagger.json
@@ -454,10 +454,10 @@
       "type": "object",
       "properties": {
         "hashedRekordRequestV002": {
-          "$ref": "#/definitions/v2HashedRekordRequestV0_0_2"
+          "$ref": "#/definitions/v2HashedRekordRequestV002"
         },
         "dsseRequestV002": {
-          "$ref": "#/definitions/v2DSSERequestV0_0_2"
+          "$ref": "#/definitions/v2DSSERequestV002"
         }
       },
       "title": "Create a new HashedRekord or DSSE",
@@ -466,7 +466,7 @@
         "dsseRequestV002"
       ]
     },
-    "v2DSSERequestV0_0_2": {
+    "v2DSSERequestV002": {
       "type": "object",
       "properties": {
         "envelope": {
@@ -482,13 +482,13 @@
           "title": "All necessary verification material to verify all signatures embedded in the envelope"
         }
       },
-      "title": "A request to add a DSSE entry to the log",
+      "title": "A request to add a DSSE v0.0.2 entry to the log",
       "required": [
         "envelope",
         "verifiers"
       ]
     },
-    "v2HashedRekordRequestV0_0_2": {
+    "v2HashedRekordRequestV002": {
       "type": "object",
       "properties": {
         "digest": {
@@ -501,7 +501,7 @@
           "title": "A single signature over the hashed data with the verifier needed to validate it"
         }
       },
-      "title": "A request to add a hashedrekord to the log",
+      "title": "A request to add a hashedrekord v0.0.2 to the log",
       "required": [
         "digest",
         "signature"

--- a/pkg/client/write/write.go
+++ b/pkg/client/write/write.go
@@ -119,27 +119,27 @@ func (w *writeClient) Add(ctx context.Context, entry any) (*pbs.TransparencyLogE
 
 func createRequest(entry any) (*pb.CreateEntryRequest, error) {
 	switch e := entry.(type) {
-	case *pb.HashedRekordRequestV0_0_2:
+	case *pb.HashedRekordRequestV002:
 		return createHashedRekordRequest(e), nil
-	case *pb.DSSERequestV0_0_2:
+	case *pb.DSSERequestV002:
 		return createDSSERequest(e), nil
 	default:
 		return nil, fmt.Errorf("unsupported entry type: %T", entry)
 	}
 }
 
-func createHashedRekordRequest(h *pb.HashedRekordRequestV0_0_2) *pb.CreateEntryRequest {
+func createHashedRekordRequest(h *pb.HashedRekordRequestV002) *pb.CreateEntryRequest {
 	return &pb.CreateEntryRequest{
-		Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
-			HashedRekordRequestV0_0_2: h,
+		Spec: &pb.CreateEntryRequest_HashedRekordRequestV002{
+			HashedRekordRequestV002: h,
 		},
 	}
 }
 
-func createDSSERequest(d *pb.DSSERequestV0_0_2) *pb.CreateEntryRequest {
+func createDSSERequest(d *pb.DSSERequestV002) *pb.CreateEntryRequest {
 	return &pb.CreateEntryRequest{
-		Spec: &pb.CreateEntryRequest_DsseRequestV0_0_2{
-			DsseRequestV0_0_2: d,
+		Spec: &pb.CreateEntryRequest_DsseRequestV002{
+			DsseRequestV002: d,
 		},
 	}
 }

--- a/pkg/client/write/write_test.go
+++ b/pkg/client/write/write_test.go
@@ -123,7 +123,7 @@ func TestAdd(t *testing.T) {
 	}{
 		{
 			name: "valid hashedrekord",
-			entry: &pb.HashedRekordRequestV0_0_2{
+			entry: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: []byte("sign"),
 					Verifier: &pb.Verifier{
@@ -157,7 +157,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "valid dsse",
-			entry: &pb.DSSERequestV0_0_2{
+			entry: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("some payload"),
 					PayloadType: "",
@@ -204,7 +204,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "server error",
-			entry: &pb.DSSERequestV0_0_2{
+			entry: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("some payload"),
 					PayloadType: "",
@@ -232,7 +232,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "unexpected response body from server",
-			entry: &pb.DSSERequestV0_0_2{
+			entry: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("some payload"),
 					PayloadType: "",
@@ -260,7 +260,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "invalid checkpoint",
-			entry: &pb.DSSERequestV0_0_2{
+			entry: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("some payload"),
 					PayloadType: "",
@@ -301,7 +301,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "invalid inclusion proof",
-			entry: &pb.DSSERequestV0_0_2{
+			entry: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("some payload"),
 					PayloadType: "",

--- a/pkg/generated/protobuf/dsse.pb.go
+++ b/pkg/generated/protobuf/dsse.pb.go
@@ -38,8 +38,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// A request to add a DSSE entry to the log
-type DSSERequestV0_0_2 struct {
+// A request to add a DSSE v0.0.2 entry to the log
+type DSSERequestV002 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A DSSE envelope
 	Envelope *dsse.Envelope `protobuf:"bytes,1,opt,name=envelope,proto3" json:"envelope,omitempty"`
@@ -49,20 +49,20 @@ type DSSERequestV0_0_2 struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DSSERequestV0_0_2) Reset() {
-	*x = DSSERequestV0_0_2{}
+func (x *DSSERequestV002) Reset() {
+	*x = DSSERequestV002{}
 	mi := &file_dsse_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DSSERequestV0_0_2) String() string {
+func (x *DSSERequestV002) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DSSERequestV0_0_2) ProtoMessage() {}
+func (*DSSERequestV002) ProtoMessage() {}
 
-func (x *DSSERequestV0_0_2) ProtoReflect() protoreflect.Message {
+func (x *DSSERequestV002) ProtoReflect() protoreflect.Message {
 	mi := &file_dsse_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -74,26 +74,26 @@ func (x *DSSERequestV0_0_2) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DSSERequestV0_0_2.ProtoReflect.Descriptor instead.
-func (*DSSERequestV0_0_2) Descriptor() ([]byte, []int) {
+// Deprecated: Use DSSERequestV002.ProtoReflect.Descriptor instead.
+func (*DSSERequestV002) Descriptor() ([]byte, []int) {
 	return file_dsse_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *DSSERequestV0_0_2) GetEnvelope() *dsse.Envelope {
+func (x *DSSERequestV002) GetEnvelope() *dsse.Envelope {
 	if x != nil {
 		return x.Envelope
 	}
 	return nil
 }
 
-func (x *DSSERequestV0_0_2) GetVerifiers() []*Verifier {
+func (x *DSSERequestV002) GetVerifiers() []*Verifier {
 	if x != nil {
 		return x.Verifiers
 	}
 	return nil
 }
 
-type DSSELogEntryV0_0_2 struct {
+type DSSELogEntryV002 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The hash of the DSSE payload
 	PayloadHash *v1.HashOutput `protobuf:"bytes,1,opt,name=payloadHash,proto3" json:"payloadHash,omitempty"`
@@ -103,20 +103,20 @@ type DSSELogEntryV0_0_2 struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DSSELogEntryV0_0_2) Reset() {
-	*x = DSSELogEntryV0_0_2{}
+func (x *DSSELogEntryV002) Reset() {
+	*x = DSSELogEntryV002{}
 	mi := &file_dsse_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DSSELogEntryV0_0_2) String() string {
+func (x *DSSELogEntryV002) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DSSELogEntryV0_0_2) ProtoMessage() {}
+func (*DSSELogEntryV002) ProtoMessage() {}
 
-func (x *DSSELogEntryV0_0_2) ProtoReflect() protoreflect.Message {
+func (x *DSSELogEntryV002) ProtoReflect() protoreflect.Message {
 	mi := &file_dsse_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -128,19 +128,19 @@ func (x *DSSELogEntryV0_0_2) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DSSELogEntryV0_0_2.ProtoReflect.Descriptor instead.
-func (*DSSELogEntryV0_0_2) Descriptor() ([]byte, []int) {
+// Deprecated: Use DSSELogEntryV002.ProtoReflect.Descriptor instead.
+func (*DSSELogEntryV002) Descriptor() ([]byte, []int) {
 	return file_dsse_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *DSSELogEntryV0_0_2) GetPayloadHash() *v1.HashOutput {
+func (x *DSSELogEntryV002) GetPayloadHash() *v1.HashOutput {
 	if x != nil {
 		return x.PayloadHash
 	}
 	return nil
 }
 
-func (x *DSSELogEntryV0_0_2) GetSignatures() []*Signature {
+func (x *DSSELogEntryV002) GetSignatures() []*Signature {
 	if x != nil {
 		return x.Signatures
 	}
@@ -152,11 +152,11 @@ var File_dsse_proto protoreflect.FileDescriptor
 const file_dsse_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"dsse.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\x1a\x15sigstore_common.proto\x1a\x0eenvelope.proto\x1a\x0everifier.proto\"\x8d\x01\n" +
-	"\x11DSSERequestV0_0_2\x124\n" +
+	"dsse.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\x1a\x15sigstore_common.proto\x1a\x0eenvelope.proto\x1a\x0everifier.proto\"\x8b\x01\n" +
+	"\x0fDSSERequestV002\x124\n" +
 	"\benvelope\x18\x01 \x01(\v2\x13.io.intoto.EnvelopeB\x03\xe0A\x02R\benvelope\x12B\n" +
-	"\tverifiers\x18\x02 \x03(\v2\x1f.dev.sigstore.rekor.v2.VerifierB\x03\xe0A\x02R\tverifiers\"\xa6\x01\n" +
-	"\x12DSSELogEntryV0_0_2\x12I\n" +
+	"\tverifiers\x18\x02 \x03(\v2\x1f.dev.sigstore.rekor.v2.VerifierB\x03\xe0A\x02R\tverifiers\"\xa4\x01\n" +
+	"\x10DSSELogEntryV002\x12I\n" +
 	"\vpayloadHash\x18\x01 \x01(\v2\".dev.sigstore.common.v1.HashOutputB\x03\xe0A\x02R\vpayloadHash\x12E\n" +
 	"\n" +
 	"signatures\x18\x02 \x03(\v2 .dev.sigstore.rekor.v2.SignatureB\x03\xe0A\x02R\n" +
@@ -176,18 +176,18 @@ func file_dsse_proto_rawDescGZIP() []byte {
 
 var file_dsse_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_dsse_proto_goTypes = []any{
-	(*DSSERequestV0_0_2)(nil),  // 0: dev.sigstore.rekor.v2.DSSERequestV0_0_2
-	(*DSSELogEntryV0_0_2)(nil), // 1: dev.sigstore.rekor.v2.DSSELogEntryV0_0_2
-	(*dsse.Envelope)(nil),      // 2: io.intoto.Envelope
-	(*Verifier)(nil),           // 3: dev.sigstore.rekor.v2.Verifier
-	(*v1.HashOutput)(nil),      // 4: dev.sigstore.common.v1.HashOutput
-	(*Signature)(nil),          // 5: dev.sigstore.rekor.v2.Signature
+	(*DSSERequestV002)(nil),  // 0: dev.sigstore.rekor.v2.DSSERequestV002
+	(*DSSELogEntryV002)(nil), // 1: dev.sigstore.rekor.v2.DSSELogEntryV002
+	(*dsse.Envelope)(nil),    // 2: io.intoto.Envelope
+	(*Verifier)(nil),         // 3: dev.sigstore.rekor.v2.Verifier
+	(*v1.HashOutput)(nil),    // 4: dev.sigstore.common.v1.HashOutput
+	(*Signature)(nil),        // 5: dev.sigstore.rekor.v2.Signature
 }
 var file_dsse_proto_depIdxs = []int32{
-	2, // 0: dev.sigstore.rekor.v2.DSSERequestV0_0_2.envelope:type_name -> io.intoto.Envelope
-	3, // 1: dev.sigstore.rekor.v2.DSSERequestV0_0_2.verifiers:type_name -> dev.sigstore.rekor.v2.Verifier
-	4, // 2: dev.sigstore.rekor.v2.DSSELogEntryV0_0_2.payloadHash:type_name -> dev.sigstore.common.v1.HashOutput
-	5, // 3: dev.sigstore.rekor.v2.DSSELogEntryV0_0_2.signatures:type_name -> dev.sigstore.rekor.v2.Signature
+	2, // 0: dev.sigstore.rekor.v2.DSSERequestV002.envelope:type_name -> io.intoto.Envelope
+	3, // 1: dev.sigstore.rekor.v2.DSSERequestV002.verifiers:type_name -> dev.sigstore.rekor.v2.Verifier
+	4, // 2: dev.sigstore.rekor.v2.DSSELogEntryV002.payloadHash:type_name -> dev.sigstore.common.v1.HashOutput
+	5, // 3: dev.sigstore.rekor.v2.DSSELogEntryV002.signatures:type_name -> dev.sigstore.rekor.v2.Signature
 	4, // [4:4] is the sub-list for method output_type
 	4, // [4:4] is the sub-list for method input_type
 	4, // [4:4] is the sub-list for extension type_name

--- a/pkg/generated/protobuf/entry.pb.go
+++ b/pkg/generated/protobuf/entry.pb.go
@@ -107,8 +107,8 @@ type Spec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Spec:
 	//
-	//	*Spec_HashedRekordV0_0_2
-	//	*Spec_DsseV0_0_2
+	//	*Spec_HashedRekordV002
+	//	*Spec_DsseV002
 	Spec          isSpec_Spec `protobuf_oneof:"spec"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -151,19 +151,19 @@ func (x *Spec) GetSpec() isSpec_Spec {
 	return nil
 }
 
-func (x *Spec) GetHashedRekordV0_0_2() *HashedRekordLogEntryV0_0_2 {
+func (x *Spec) GetHashedRekordV002() *HashedRekordLogEntryV002 {
 	if x != nil {
-		if x, ok := x.Spec.(*Spec_HashedRekordV0_0_2); ok {
-			return x.HashedRekordV0_0_2
+		if x, ok := x.Spec.(*Spec_HashedRekordV002); ok {
+			return x.HashedRekordV002
 		}
 	}
 	return nil
 }
 
-func (x *Spec) GetDsseV0_0_2() *DSSELogEntryV0_0_2 {
+func (x *Spec) GetDsseV002() *DSSELogEntryV002 {
 	if x != nil {
-		if x, ok := x.Spec.(*Spec_DsseV0_0_2); ok {
-			return x.DsseV0_0_2
+		if x, ok := x.Spec.(*Spec_DsseV002); ok {
+			return x.DsseV002
 		}
 	}
 	return nil
@@ -173,17 +173,17 @@ type isSpec_Spec interface {
 	isSpec_Spec()
 }
 
-type Spec_HashedRekordV0_0_2 struct {
-	HashedRekordV0_0_2 *HashedRekordLogEntryV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_v0_0_2,json=hashedRekordV002,proto3,oneof"`
+type Spec_HashedRekordV002 struct {
+	HashedRekordV002 *HashedRekordLogEntryV002 `protobuf:"bytes,1,opt,name=hashed_rekord_v002,json=hashedRekordV002,proto3,oneof"`
 }
 
-type Spec_DsseV0_0_2 struct {
-	DsseV0_0_2 *DSSELogEntryV0_0_2 `protobuf:"bytes,2,opt,name=dsse_v0_0_2,json=dsseV002,proto3,oneof"`
+type Spec_DsseV002 struct {
+	DsseV002 *DSSELogEntryV002 `protobuf:"bytes,2,opt,name=dsse_v002,json=dsseV002,proto3,oneof"`
 }
 
-func (*Spec_HashedRekordV0_0_2) isSpec_Spec() {}
+func (*Spec_HashedRekordV002) isSpec_Spec() {}
 
-func (*Spec_DsseV0_0_2) isSpec_Spec() {}
+func (*Spec_DsseV002) isSpec_Spec() {}
 
 var File_entry_proto protoreflect.FileDescriptor
 
@@ -195,10 +195,10 @@ const file_entry_proto_rawDesc = "" +
 	"\x04kind\x18\x01 \x01(\tB\x03\xe0A\x02R\x04kind\x12$\n" +
 	"\vapi_version\x18\x02 \x01(\tB\x03\xe0A\x02R\n" +
 	"apiVersion\x124\n" +
-	"\x04spec\x18\x03 \x01(\v2\x1b.dev.sigstore.rekor.v2.SpecB\x03\xe0A\x02R\x04spec\"\xc9\x01\n" +
-	"\x04Spec\x12h\n" +
-	"\x14hashed_rekord_v0_0_2\x18\x01 \x01(\v21.dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2B\x03\xe0A\x02H\x00R\x10hashedRekordV002\x12O\n" +
-	"\vdsse_v0_0_2\x18\x02 \x01(\v2).dev.sigstore.rekor.v2.DSSELogEntryV0_0_2B\x03\xe0A\x02H\x00R\bdsseV002B\x06\n" +
+	"\x04spec\x18\x03 \x01(\v2\x1b.dev.sigstore.rekor.v2.SpecB\x03\xe0A\x02R\x04spec\"\xc1\x01\n" +
+	"\x04Spec\x12d\n" +
+	"\x12hashed_rekord_v002\x18\x01 \x01(\v2/.dev.sigstore.rekor.v2.HashedRekordLogEntryV002B\x03\xe0A\x02H\x00R\x10hashedRekordV002\x12K\n" +
+	"\tdsse_v002\x18\x02 \x01(\v2'.dev.sigstore.rekor.v2.DSSELogEntryV002B\x03\xe0A\x02H\x00R\bdsseV002B\x06\n" +
 	"\x04specB8Z6github.com/sigstore/rekor-tiles/pkg/generated/protobufb\x06proto3"
 
 var (
@@ -215,15 +215,15 @@ func file_entry_proto_rawDescGZIP() []byte {
 
 var file_entry_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_entry_proto_goTypes = []any{
-	(*Entry)(nil),                      // 0: dev.sigstore.rekor.v2.Entry
-	(*Spec)(nil),                       // 1: dev.sigstore.rekor.v2.Spec
-	(*HashedRekordLogEntryV0_0_2)(nil), // 2: dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2
-	(*DSSELogEntryV0_0_2)(nil),         // 3: dev.sigstore.rekor.v2.DSSELogEntryV0_0_2
+	(*Entry)(nil),                    // 0: dev.sigstore.rekor.v2.Entry
+	(*Spec)(nil),                     // 1: dev.sigstore.rekor.v2.Spec
+	(*HashedRekordLogEntryV002)(nil), // 2: dev.sigstore.rekor.v2.HashedRekordLogEntryV002
+	(*DSSELogEntryV002)(nil),         // 3: dev.sigstore.rekor.v2.DSSELogEntryV002
 }
 var file_entry_proto_depIdxs = []int32{
 	1, // 0: dev.sigstore.rekor.v2.Entry.spec:type_name -> dev.sigstore.rekor.v2.Spec
-	2, // 1: dev.sigstore.rekor.v2.Spec.hashed_rekord_v0_0_2:type_name -> dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2
-	3, // 2: dev.sigstore.rekor.v2.Spec.dsse_v0_0_2:type_name -> dev.sigstore.rekor.v2.DSSELogEntryV0_0_2
+	2, // 1: dev.sigstore.rekor.v2.Spec.hashed_rekord_v002:type_name -> dev.sigstore.rekor.v2.HashedRekordLogEntryV002
+	3, // 2: dev.sigstore.rekor.v2.Spec.dsse_v002:type_name -> dev.sigstore.rekor.v2.DSSELogEntryV002
 	3, // [3:3] is the sub-list for method output_type
 	3, // [3:3] is the sub-list for method input_type
 	3, // [3:3] is the sub-list for extension type_name
@@ -239,8 +239,8 @@ func file_entry_proto_init() {
 	file_dsse_proto_init()
 	file_hashedrekord_proto_init()
 	file_entry_proto_msgTypes[1].OneofWrappers = []any{
-		(*Spec_HashedRekordV0_0_2)(nil),
-		(*Spec_DsseV0_0_2)(nil),
+		(*Spec_HashedRekordV002)(nil),
+		(*Spec_DsseV002)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/pkg/generated/protobuf/hashedrekord.pb.go
+++ b/pkg/generated/protobuf/hashedrekord.pb.go
@@ -37,8 +37,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// A request to add a hashedrekord to the log
-type HashedRekordRequestV0_0_2 struct {
+// A request to add a hashedrekord v0.0.2 to the log
+type HashedRekordRequestV002 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The hashed data
 	Digest []byte `protobuf:"bytes,1,opt,name=digest,proto3" json:"digest,omitempty"`
@@ -48,20 +48,20 @@ type HashedRekordRequestV0_0_2 struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *HashedRekordRequestV0_0_2) Reset() {
-	*x = HashedRekordRequestV0_0_2{}
+func (x *HashedRekordRequestV002) Reset() {
+	*x = HashedRekordRequestV002{}
 	mi := &file_hashedrekord_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *HashedRekordRequestV0_0_2) String() string {
+func (x *HashedRekordRequestV002) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*HashedRekordRequestV0_0_2) ProtoMessage() {}
+func (*HashedRekordRequestV002) ProtoMessage() {}
 
-func (x *HashedRekordRequestV0_0_2) ProtoReflect() protoreflect.Message {
+func (x *HashedRekordRequestV002) ProtoReflect() protoreflect.Message {
 	mi := &file_hashedrekord_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -73,26 +73,26 @@ func (x *HashedRekordRequestV0_0_2) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use HashedRekordRequestV0_0_2.ProtoReflect.Descriptor instead.
-func (*HashedRekordRequestV0_0_2) Descriptor() ([]byte, []int) {
+// Deprecated: Use HashedRekordRequestV002.ProtoReflect.Descriptor instead.
+func (*HashedRekordRequestV002) Descriptor() ([]byte, []int) {
 	return file_hashedrekord_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *HashedRekordRequestV0_0_2) GetDigest() []byte {
+func (x *HashedRekordRequestV002) GetDigest() []byte {
 	if x != nil {
 		return x.Digest
 	}
 	return nil
 }
 
-func (x *HashedRekordRequestV0_0_2) GetSignature() *Signature {
+func (x *HashedRekordRequestV002) GetSignature() *Signature {
 	if x != nil {
 		return x.Signature
 	}
 	return nil
 }
 
-type HashedRekordLogEntryV0_0_2 struct {
+type HashedRekordLogEntryV002 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The hashed data
 	Data *v1.HashOutput `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
@@ -102,20 +102,20 @@ type HashedRekordLogEntryV0_0_2 struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *HashedRekordLogEntryV0_0_2) Reset() {
-	*x = HashedRekordLogEntryV0_0_2{}
+func (x *HashedRekordLogEntryV002) Reset() {
+	*x = HashedRekordLogEntryV002{}
 	mi := &file_hashedrekord_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *HashedRekordLogEntryV0_0_2) String() string {
+func (x *HashedRekordLogEntryV002) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*HashedRekordLogEntryV0_0_2) ProtoMessage() {}
+func (*HashedRekordLogEntryV002) ProtoMessage() {}
 
-func (x *HashedRekordLogEntryV0_0_2) ProtoReflect() protoreflect.Message {
+func (x *HashedRekordLogEntryV002) ProtoReflect() protoreflect.Message {
 	mi := &file_hashedrekord_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -127,19 +127,19 @@ func (x *HashedRekordLogEntryV0_0_2) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use HashedRekordLogEntryV0_0_2.ProtoReflect.Descriptor instead.
-func (*HashedRekordLogEntryV0_0_2) Descriptor() ([]byte, []int) {
+// Deprecated: Use HashedRekordLogEntryV002.ProtoReflect.Descriptor instead.
+func (*HashedRekordLogEntryV002) Descriptor() ([]byte, []int) {
 	return file_hashedrekord_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *HashedRekordLogEntryV0_0_2) GetData() *v1.HashOutput {
+func (x *HashedRekordLogEntryV002) GetData() *v1.HashOutput {
 	if x != nil {
 		return x.Data
 	}
 	return nil
 }
 
-func (x *HashedRekordLogEntryV0_0_2) GetSignature() *Signature {
+func (x *HashedRekordLogEntryV002) GetSignature() *Signature {
 	if x != nil {
 		return x.Signature
 	}
@@ -150,11 +150,11 @@ var File_hashedrekord_proto protoreflect.FileDescriptor
 
 const file_hashedrekord_proto_rawDesc = "" +
 	"\n" +
-	"\x12hashedrekord.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\x1a\x15sigstore_common.proto\x1a\x0everifier.proto\"}\n" +
-	"\x19HashedRekordRequestV0_0_2\x12\x1b\n" +
+	"\x12hashedrekord.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\x1a\x15sigstore_common.proto\x1a\x0everifier.proto\"{\n" +
+	"\x17HashedRekordRequestV002\x12\x1b\n" +
 	"\x06digest\x18\x01 \x01(\fB\x03\xe0A\x02R\x06digest\x12C\n" +
-	"\tsignature\x18\x02 \x01(\v2 .dev.sigstore.rekor.v2.SignatureB\x03\xe0A\x02R\tsignature\"\x9e\x01\n" +
-	"\x1aHashedRekordLogEntryV0_0_2\x12;\n" +
+	"\tsignature\x18\x02 \x01(\v2 .dev.sigstore.rekor.v2.SignatureB\x03\xe0A\x02R\tsignature\"\x9c\x01\n" +
+	"\x18HashedRekordLogEntryV002\x12;\n" +
 	"\x04data\x18\x01 \x01(\v2\".dev.sigstore.common.v1.HashOutputB\x03\xe0A\x02R\x04data\x12C\n" +
 	"\tsignature\x18\x02 \x01(\v2 .dev.sigstore.rekor.v2.SignatureB\x03\xe0A\x02R\tsignatureB8Z6github.com/sigstore/rekor-tiles/pkg/generated/protobufb\x06proto3"
 
@@ -172,15 +172,15 @@ func file_hashedrekord_proto_rawDescGZIP() []byte {
 
 var file_hashedrekord_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_hashedrekord_proto_goTypes = []any{
-	(*HashedRekordRequestV0_0_2)(nil),  // 0: dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
-	(*HashedRekordLogEntryV0_0_2)(nil), // 1: dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2
-	(*Signature)(nil),                  // 2: dev.sigstore.rekor.v2.Signature
-	(*v1.HashOutput)(nil),              // 3: dev.sigstore.common.v1.HashOutput
+	(*HashedRekordRequestV002)(nil),  // 0: dev.sigstore.rekor.v2.HashedRekordRequestV002
+	(*HashedRekordLogEntryV002)(nil), // 1: dev.sigstore.rekor.v2.HashedRekordLogEntryV002
+	(*Signature)(nil),                // 2: dev.sigstore.rekor.v2.Signature
+	(*v1.HashOutput)(nil),            // 3: dev.sigstore.common.v1.HashOutput
 }
 var file_hashedrekord_proto_depIdxs = []int32{
-	2, // 0: dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2.signature:type_name -> dev.sigstore.rekor.v2.Signature
-	3, // 1: dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2.data:type_name -> dev.sigstore.common.v1.HashOutput
-	2, // 2: dev.sigstore.rekor.v2.HashedRekordLogEntryV0_0_2.signature:type_name -> dev.sigstore.rekor.v2.Signature
+	2, // 0: dev.sigstore.rekor.v2.HashedRekordRequestV002.signature:type_name -> dev.sigstore.rekor.v2.Signature
+	3, // 1: dev.sigstore.rekor.v2.HashedRekordLogEntryV002.data:type_name -> dev.sigstore.common.v1.HashOutput
+	2, // 2: dev.sigstore.rekor.v2.HashedRekordLogEntryV002.signature:type_name -> dev.sigstore.rekor.v2.Signature
 	3, // [3:3] is the sub-list for method output_type
 	3, // [3:3] is the sub-list for method input_type
 	3, // [3:3] is the sub-list for extension type_name

--- a/pkg/generated/protobuf/rekor_service.pb.go
+++ b/pkg/generated/protobuf/rekor_service.pb.go
@@ -44,8 +44,8 @@ type CreateEntryRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Spec:
 	//
-	//	*CreateEntryRequest_HashedRekordRequestV0_0_2
-	//	*CreateEntryRequest_DsseRequestV0_0_2
+	//	*CreateEntryRequest_HashedRekordRequestV002
+	//	*CreateEntryRequest_DsseRequestV002
 	Spec          isCreateEntryRequest_Spec `protobuf_oneof:"spec"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -88,19 +88,19 @@ func (x *CreateEntryRequest) GetSpec() isCreateEntryRequest_Spec {
 	return nil
 }
 
-func (x *CreateEntryRequest) GetHashedRekordRequestV0_0_2() *HashedRekordRequestV0_0_2 {
+func (x *CreateEntryRequest) GetHashedRekordRequestV002() *HashedRekordRequestV002 {
 	if x != nil {
-		if x, ok := x.Spec.(*CreateEntryRequest_HashedRekordRequestV0_0_2); ok {
-			return x.HashedRekordRequestV0_0_2
+		if x, ok := x.Spec.(*CreateEntryRequest_HashedRekordRequestV002); ok {
+			return x.HashedRekordRequestV002
 		}
 	}
 	return nil
 }
 
-func (x *CreateEntryRequest) GetDsseRequestV0_0_2() *DSSERequestV0_0_2 {
+func (x *CreateEntryRequest) GetDsseRequestV002() *DSSERequestV002 {
 	if x != nil {
-		if x, ok := x.Spec.(*CreateEntryRequest_DsseRequestV0_0_2); ok {
-			return x.DsseRequestV0_0_2
+		if x, ok := x.Spec.(*CreateEntryRequest_DsseRequestV002); ok {
+			return x.DsseRequestV002
 		}
 	}
 	return nil
@@ -110,17 +110,17 @@ type isCreateEntryRequest_Spec interface {
 	isCreateEntryRequest_Spec()
 }
 
-type CreateEntryRequest_HashedRekordRequestV0_0_2 struct {
-	HashedRekordRequestV0_0_2 *HashedRekordRequestV0_0_2 `protobuf:"bytes,1,opt,name=hashed_rekord_request_v0_0_2,json=hashedRekordRequestV002,proto3,oneof"`
+type CreateEntryRequest_HashedRekordRequestV002 struct {
+	HashedRekordRequestV002 *HashedRekordRequestV002 `protobuf:"bytes,1,opt,name=hashed_rekord_request_v002,json=hashedRekordRequestV002,proto3,oneof"`
 }
 
-type CreateEntryRequest_DsseRequestV0_0_2 struct {
-	DsseRequestV0_0_2 *DSSERequestV0_0_2 `protobuf:"bytes,2,opt,name=dsse_request_v0_0_2,json=dsseRequestV002,proto3,oneof"`
+type CreateEntryRequest_DsseRequestV002 struct {
+	DsseRequestV002 *DSSERequestV002 `protobuf:"bytes,2,opt,name=dsse_request_v002,json=dsseRequestV002,proto3,oneof"`
 }
 
-func (*CreateEntryRequest_HashedRekordRequestV0_0_2) isCreateEntryRequest_Spec() {}
+func (*CreateEntryRequest_HashedRekordRequestV002) isCreateEntryRequest_Spec() {}
 
-func (*CreateEntryRequest_DsseRequestV0_0_2) isCreateEntryRequest_Spec() {}
+func (*CreateEntryRequest_DsseRequestV002) isCreateEntryRequest_Spec() {}
 
 // Request for a full or partial tile (see https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#merkle-tree)
 type TileRequest struct {
@@ -229,10 +229,10 @@ var File_rekor_service_proto protoreflect.FileDescriptor
 const file_rekor_service_proto_rawDesc = "" +
 	"\n" +
 	"\x13rekor_service.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x19google/api/httpbody.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x14sigstore_rekor.proto\x1a\x12hashedrekord.proto\x1a\n" +
-	"dsse.proto\"\xf3\x01\n" +
-	"\x12CreateEntryRequest\x12v\n" +
-	"\x1chashed_rekord_request_v0_0_2\x18\x01 \x01(\v20.dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2B\x03\xe0A\x02H\x00R\x17hashedRekordRequestV002\x12]\n" +
-	"\x13dsse_request_v0_0_2\x18\x02 \x01(\v2(.dev.sigstore.rekor.v2.DSSERequestV0_0_2B\x03\xe0A\x02H\x00R\x0fdsseRequestV002B\x06\n" +
+	"dsse.proto\"\xeb\x01\n" +
+	"\x12CreateEntryRequest\x12r\n" +
+	"\x1ahashed_rekord_request_v002\x18\x01 \x01(\v2..dev.sigstore.rekor.v2.HashedRekordRequestV002B\x03\xe0A\x02H\x00R\x17hashedRekordRequestV002\x12Y\n" +
+	"\x11dsse_request_v002\x18\x02 \x01(\v2&.dev.sigstore.rekor.v2.DSSERequestV002B\x03\xe0A\x02H\x00R\x0fdsseRequestV002B\x06\n" +
 	"\x04spec\")\n" +
 	"\vTileRequest\x12\f\n" +
 	"\x01L\x18\x01 \x01(\rR\x01L\x12\f\n" +
@@ -259,18 +259,18 @@ func file_rekor_service_proto_rawDescGZIP() []byte {
 
 var file_rekor_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_rekor_service_proto_goTypes = []any{
-	(*CreateEntryRequest)(nil),        // 0: dev.sigstore.rekor.v2.CreateEntryRequest
-	(*TileRequest)(nil),               // 1: dev.sigstore.rekor.v2.TileRequest
-	(*EntryBundleRequest)(nil),        // 2: dev.sigstore.rekor.v2.EntryBundleRequest
-	(*HashedRekordRequestV0_0_2)(nil), // 3: dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
-	(*DSSERequestV0_0_2)(nil),         // 4: dev.sigstore.rekor.v2.DSSERequestV0_0_2
-	(*emptypb.Empty)(nil),             // 5: google.protobuf.Empty
-	(*v1.TransparencyLogEntry)(nil),   // 6: dev.sigstore.rekor.v1.TransparencyLogEntry
-	(*httpbody.HttpBody)(nil),         // 7: google.api.HttpBody
+	(*CreateEntryRequest)(nil),      // 0: dev.sigstore.rekor.v2.CreateEntryRequest
+	(*TileRequest)(nil),             // 1: dev.sigstore.rekor.v2.TileRequest
+	(*EntryBundleRequest)(nil),      // 2: dev.sigstore.rekor.v2.EntryBundleRequest
+	(*HashedRekordRequestV002)(nil), // 3: dev.sigstore.rekor.v2.HashedRekordRequestV002
+	(*DSSERequestV002)(nil),         // 4: dev.sigstore.rekor.v2.DSSERequestV002
+	(*emptypb.Empty)(nil),           // 5: google.protobuf.Empty
+	(*v1.TransparencyLogEntry)(nil), // 6: dev.sigstore.rekor.v1.TransparencyLogEntry
+	(*httpbody.HttpBody)(nil),       // 7: google.api.HttpBody
 }
 var file_rekor_service_proto_depIdxs = []int32{
-	3, // 0: dev.sigstore.rekor.v2.CreateEntryRequest.hashed_rekord_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.HashedRekordRequestV0_0_2
-	4, // 1: dev.sigstore.rekor.v2.CreateEntryRequest.dsse_request_v0_0_2:type_name -> dev.sigstore.rekor.v2.DSSERequestV0_0_2
+	3, // 0: dev.sigstore.rekor.v2.CreateEntryRequest.hashed_rekord_request_v002:type_name -> dev.sigstore.rekor.v2.HashedRekordRequestV002
+	4, // 1: dev.sigstore.rekor.v2.CreateEntryRequest.dsse_request_v002:type_name -> dev.sigstore.rekor.v2.DSSERequestV002
 	0, // 2: dev.sigstore.rekor.v2.Rekor.CreateEntry:input_type -> dev.sigstore.rekor.v2.CreateEntryRequest
 	1, // 3: dev.sigstore.rekor.v2.Rekor.GetTile:input_type -> dev.sigstore.rekor.v2.TileRequest
 	2, // 4: dev.sigstore.rekor.v2.Rekor.GetEntryBundle:input_type -> dev.sigstore.rekor.v2.EntryBundleRequest
@@ -294,8 +294,8 @@ func file_rekor_service_proto_init() {
 	file_hashedrekord_proto_init()
 	file_dsse_proto_init()
 	file_rekor_service_proto_msgTypes[0].OneofWrappers = []any{
-		(*CreateEntryRequest_HashedRekordRequestV0_0_2)(nil),
-		(*CreateEntryRequest_DsseRequestV0_0_2)(nil),
+		(*CreateEntryRequest_HashedRekordRequestV002)(nil),
+		(*CreateEntryRequest_DsseRequestV002)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -81,8 +81,8 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 	var metricsCounter prometheus.Counter
 	var kv *pbs.KindVersion
 	switch req.GetSpec().(type) {
-	case *pb.CreateEntryRequest_HashedRekordRequestV0_0_2:
-		hr := req.GetHashedRekordRequestV0_0_2()
+	case *pb.CreateEntryRequest_HashedRekordRequestV002:
+		hr := req.GetHashedRekordRequestV002()
 		entry, err := hashedrekord.ToLogEntry(hr, s.algorithmRegistry)
 		if err != nil {
 			slog.WarnContext(ctx, "failed validating hashedrekord request", "error", err.Error())
@@ -98,8 +98,8 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 			return nil, status.Errorf(codes.InvalidArgument, "invalid hashedrekord request")
 		}
 		metricsCounter = getMetrics().newHashedRekordEntries
-	case *pb.CreateEntryRequest_DsseRequestV0_0_2:
-		ds := req.GetDsseRequestV0_0_2()
+	case *pb.CreateEntryRequest_DsseRequestV002:
+		ds := req.GetDsseRequestV002()
 		entry, err := dsse.ToLogEntry(ds, s.algorithmRegistry)
 		if err != nil {
 			slog.WarnContext(ctx, "failed validating dsse request", "error", err.Error())

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -54,8 +54,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "valid hashedrekord",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
-					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV002{
+					HashedRekordRequestV002: &pb.HashedRekordRequestV002{
 						Signature: &pb.Signature{
 							Content: b64DecodeOrDie(t, "MEYCIQC59oLS3MsCqm0xCxPOy+8FdQK4RYCZE036s3q1ECfcagIhAJ4ATXlCSdFrklKAS8No0PsAE9uLi37TCbIfRXASJTTb"),
 							Verifier: &pb.Verifier{
@@ -77,8 +77,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "valid dsse",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_DsseRequestV0_0_2{
-					DsseRequestV0_0_2: &pb.DSSERequestV0_0_2{
+				Spec: &pb.CreateEntryRequest_DsseRequestV002{
+					DsseRequestV002: &pb.DSSERequestV002{
 						Envelope: &dsse.Envelope{
 							Payload:     b64DecodeOrDie(t, "cGF5bG9hZA=="),
 							PayloadType: "application/vnd.in-toto+json",
@@ -108,8 +108,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "invalid hashedrekord",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
-					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{},
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV002{
+					HashedRekordRequestV002: &pb.HashedRekordRequestV002{},
 				},
 			},
 			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
@@ -119,8 +119,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "invalid dsse",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_DsseRequestV0_0_2{
-					DsseRequestV0_0_2: &pb.DSSERequestV0_0_2{},
+				Spec: &pb.CreateEntryRequest_DsseRequestV002{
+					DsseRequestV002: &pb.DSSERequestV002{},
 				},
 			},
 			addFn:                   func() (*rekor_pb.TransparencyLogEntry, error) { return &rekor_pb.TransparencyLogEntry{}, nil },
@@ -130,8 +130,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "failed integration",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
-					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV002{
+					HashedRekordRequestV002: &pb.HashedRekordRequestV002{
 						Signature: &pb.Signature{
 							Content: b64DecodeOrDie(t, "MEYCIQC59oLS3MsCqm0xCxPOy+8FdQK4RYCZE036s3q1ECfcagIhAJ4ATXlCSdFrklKAS8No0PsAE9uLi37TCbIfRXASJTTb"),
 							Verifier: &pb.Verifier{
@@ -154,8 +154,8 @@ func TestCreateEntry(t *testing.T) {
 		{
 			name: "hashedrekord signed with disallowed algorithm",
 			req: &pb.CreateEntryRequest{
-				Spec: &pb.CreateEntryRequest_HashedRekordRequestV0_0_2{
-					HashedRekordRequestV0_0_2: &pb.HashedRekordRequestV0_0_2{
+				Spec: &pb.CreateEntryRequest_HashedRekordRequestV002{
+					HashedRekordRequestV002: &pb.HashedRekordRequestV002{
 						Signature: &pb.Signature{
 							Content: b64DecodeOrDie(t, "MEYCIQC59oLS3MsCqm0xCxPOy+8FdQK4RYCZE036s3q1ECfcagIhAJ4ATXlCSdFrklKAS8No0PsAE9uLi37TCbIfRXASJTTb"),
 							Verifier: &pb.Verifier{

--- a/pkg/types/dsse/dsse.go
+++ b/pkg/types/dsse/dsse.go
@@ -37,7 +37,7 @@ import (
 )
 
 // ToLogEntry validates a request, verifies all envelope signatures, and converts it to a log entry type for inclusion in the log
-func ToLogEntry(ds *pb.DSSERequestV0_0_2, algorithmRegistry *signature.AlgorithmRegistryConfig) (*pb.Entry, error) {
+func ToLogEntry(ds *pb.DSSERequestV002, algorithmRegistry *signature.AlgorithmRegistryConfig) (*pb.Entry, error) {
 	if err := validate(ds); err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func ToLogEntry(ds *pb.DSSERequestV0_0_2, algorithmRegistry *signature.Algorithm
 		Kind:       "dsse",
 		ApiVersion: "0.0.2",
 		Spec: &pb.Spec{
-			Spec: &pb.Spec_DsseV0_0_2{
-				DsseV0_0_2: &pb.DSSELogEntryV0_0_2{
+			Spec: &pb.Spec_DsseV002{
+				DsseV002: &pb.DSSELogEntryV002{
 					PayloadHash: &v1.HashOutput{
 						Algorithm: v1.HashAlgorithm_SHA2_256,
 						Digest:    payloadHash[:],
@@ -86,8 +86,8 @@ func ToLogEntry(ds *pb.DSSERequestV0_0_2, algorithmRegistry *signature.Algorithm
 	}, nil
 }
 
-// validate validates there are no missing fields in a DSSERequestV0_0_2 protobuf
-func validate(ds *pb.DSSERequestV0_0_2) error {
+// validate validates there are no missing fields in a DSSERequestV002 protobuf
+func validate(ds *pb.DSSERequestV002) error {
 	if ds.Envelope == nil {
 		return fmt.Errorf("missing envelope")
 	}
@@ -111,7 +111,7 @@ func validate(ds *pb.DSSERequestV0_0_2) error {
 }
 
 // extractVerifiers returns a map of protobuf verifiers to verifier interface
-func extractVerifiers(ds *pb.DSSERequestV0_0_2) (map[*pb.Verifier]verifier.Verifier, error) {
+func extractVerifiers(ds *pb.DSSERequestV002) (map[*pb.Verifier]verifier.Verifier, error) {
 	verifiers := make(map[*pb.Verifier]verifier.Verifier, 0)
 	for _, v := range ds.Verifiers {
 		pubKey := v.GetPublicKey()

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -85,14 +85,14 @@ func TestToLogEntry(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		dsse              *pb.DSSERequestV0_0_2
+		dsse              *pb.DSSERequestV002
 		allowedAlgorithms []v1.PublicKeyDetails
 		expectErr         error
 		expectedEntry     *pb.Entry
 	}{
 		{
 			name: "valid dsse",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -118,8 +118,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "dsse",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_DsseV0_0_2{
-						DsseV0_0_2: &pb.DSSELogEntryV0_0_2{
+					Spec: &pb.Spec_DsseV002{
+						DsseV002: &pb.DSSELogEntryV002{
 							PayloadHash: &v1.HashOutput{
 								Algorithm: v1.HashAlgorithm_SHA2_256,
 								Digest:    payloadHash[:],
@@ -144,7 +144,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing envelope",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Verifiers: []*pb.Verifier{
 					{
 						Verifier: &pb.Verifier_PublicKey{
@@ -160,7 +160,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing verifiers",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -176,7 +176,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "invalid verifier",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     []byte("payload"),
 					PayloadType: "application/vnd.in-toto+json",
@@ -200,7 +200,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing signatures",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -220,7 +220,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "empty signatures",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -241,7 +241,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "invalid signature",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -267,7 +267,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "valid dsse with X.509 cert",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -293,8 +293,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "dsse",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_DsseV0_0_2{
-						DsseV0_0_2: &pb.DSSELogEntryV0_0_2{
+					Spec: &pb.Spec_DsseV002{
+						DsseV002: &pb.DSSELogEntryV002{
 							PayloadHash: &v1.HashOutput{
 								Algorithm: v1.HashAlgorithm_SHA2_256,
 								Digest:    payloadHash[:],
@@ -319,7 +319,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "mismatched key algorithm",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -346,7 +346,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "valid DSSE with multiple signatures, different algorithm",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -384,8 +384,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "dsse",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_DsseV0_0_2{
-						DsseV0_0_2: &pb.DSSELogEntryV0_0_2{
+					Spec: &pb.Spec_DsseV002{
+						DsseV002: &pb.DSSELogEntryV002{
 							PayloadHash: &v1.HashOutput{
 								Algorithm: v1.HashAlgorithm_SHA2_256,
 								Digest:    payloadHash[:],
@@ -423,7 +423,7 @@ func TestToLogEntry(t *testing.T) {
 			// test input is same as "valid DSSE with multiple signatures, different algorithm",
 			// but with signature input swapped, to show that response signature order is canonicalized
 			name: "valid DSSE with multiple signatures in consistent order",
-			dsse: &pb.DSSERequestV0_0_2{
+			dsse: &pb.DSSERequestV002{
 				Envelope: &dsse.Envelope{
 					Payload:     payload,
 					PayloadType: "application/vnd.in-toto+json",
@@ -461,8 +461,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "dsse",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_DsseV0_0_2{
-						DsseV0_0_2: &pb.DSSELogEntryV0_0_2{
+					Spec: &pb.Spec_DsseV002{
+						DsseV002: &pb.DSSELogEntryV002{
 							PayloadHash: &v1.HashOutput{
 								Algorithm: v1.HashAlgorithm_SHA2_256,
 								Digest:    payloadHash[:],

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ToLogEntry validates a request, verifies its signature, and converts it to a log entry type for inclusion in the log
-func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.AlgorithmRegistryConfig) (*pb.Entry, error) {
+func ToLogEntry(hr *pb.HashedRekordRequestV002, algorithmRegistry *signature.AlgorithmRegistryConfig) (*pb.Entry, error) {
 	if err := validate(hr); err != nil {
 		return nil, err
 	}
@@ -54,8 +54,8 @@ func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.A
 		Kind:       "hashedrekord",
 		ApiVersion: "0.0.2",
 		Spec: &pb.Spec{
-			Spec: &pb.Spec_HashedRekordV0_0_2{
-				HashedRekordV0_0_2: &pb.HashedRekordLogEntryV0_0_2{
+			Spec: &pb.Spec_HashedRekordV002{
+				HashedRekordV002: &pb.HashedRekordLogEntryV002{
 					Signature: hr.Signature,
 					Data:      &v1.HashOutput{Digest: hr.Digest, Algorithm: algDetails.GetProtoHashType()},
 				},
@@ -64,8 +64,8 @@ func ToLogEntry(hr *pb.HashedRekordRequestV0_0_2, algorithmRegistry *signature.A
 	}, nil
 }
 
-// validate validates there are no missing fields in a HashedRekordRequestV0_0_2 protobuf
-func validate(hr *pb.HashedRekordRequestV0_0_2) error {
+// validate validates there are no missing fields in a HashedRekordRequestV002 protobuf
+func validate(hr *pb.HashedRekordRequestV002) error {
 	if hr.Signature == nil || len(hr.Signature.Content) == 0 {
 		return fmt.Errorf("missing signature")
 	}
@@ -81,7 +81,7 @@ func validate(hr *pb.HashedRekordRequestV0_0_2) error {
 	return nil
 }
 
-func extractVerifier(hr *pb.HashedRekordRequestV0_0_2) (verifier.Verifier, error) {
+func extractVerifier(hr *pb.HashedRekordRequestV002) (verifier.Verifier, error) {
 	var v verifier.Verifier
 	var err error
 	if pubKey := hr.Signature.Verifier.GetPublicKey(); pubKey != nil {
@@ -116,7 +116,7 @@ func verifySupportedAlgorithm(keyDetails v1.PublicKeyDetails, v verifier.Verifie
 	return algDetails, nil
 }
 
-func verifySignature(hr *pb.HashedRekordRequestV0_0_2, v verifier.Verifier, hashAlg crypto.Hash) error {
+func verifySignature(hr *pb.HashedRekordRequestV002, v verifier.Verifier, hashAlg crypto.Hash) error {
 	sigVerifier, err := signature.LoadVerifierWithOpts(v.PublicKey(), options.WithED25519ph())
 	if err != nil {
 		return fmt.Errorf("loading verifier: %v", err)

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -79,14 +79,14 @@ func TestToLogEntry(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		hashedrekord      *pb.HashedRekordRequestV0_0_2
+		hashedrekord      *pb.HashedRekordRequestV002
 		allowedAlgorithms []v1.PublicKeyDetails
 		expectErr         error
 		expectedEntry     *pb.Entry
 	}{
 		{
 			name: "valid hashedrekord",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignature),
 					Verifier: &pb.Verifier{
@@ -104,8 +104,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "hashedrekord",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_HashedRekordV0_0_2{
-						HashedRekordV0_0_2: &pb.HashedRekordLogEntryV0_0_2{
+					Spec: &pb.Spec_HashedRekordV002{
+						HashedRekordV002: &pb.HashedRekordLogEntryV002{
 							Data: &v1.HashOutput{
 								Digest:    hexDecodeOrDie(t, hexEncodedDigest),
 								Algorithm: v1.HashAlgorithm_SHA2_256,
@@ -128,7 +128,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing signature",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Verifier: &pb.Verifier{
 						Verifier: &pb.Verifier_PublicKey{
@@ -145,7 +145,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing verifier",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignature),
 				},
@@ -155,7 +155,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "missing digest",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignature),
 					Verifier: &pb.Verifier{
@@ -172,7 +172,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "invalid verifier",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: []byte("sig"),
 					Verifier: &pb.Verifier{
@@ -188,7 +188,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "invalid signature",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: []byte("foobar"),
 					Verifier: &pb.Verifier{
@@ -206,7 +206,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "valid hashedrekord with X.509 cert",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignature),
 					Verifier: &pb.Verifier{
@@ -224,8 +224,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "hashedrekord",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_HashedRekordV0_0_2{
-						HashedRekordV0_0_2: &pb.HashedRekordLogEntryV0_0_2{
+					Spec: &pb.Spec_HashedRekordV002{
+						HashedRekordV002: &pb.HashedRekordLogEntryV002{
 							Data: &v1.HashOutput{
 								Digest:    hexDecodeOrDie(t, hexEncodedDigest),
 								Algorithm: v1.HashAlgorithm_SHA2_256,
@@ -248,7 +248,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "mismatched key algorithm",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignature),
 					Verifier: &pb.Verifier{
@@ -267,7 +267,7 @@ func TestToLogEntry(t *testing.T) {
 		},
 		{
 			name: "valid hashedrekord with different algorithm",
-			hashedrekord: &pb.HashedRekordRequestV0_0_2{
+			hashedrekord: &pb.HashedRekordRequestV002{
 				Signature: &pb.Signature{
 					Content: b64DecodeOrDie(t, b64EncodedSignatureP384),
 					Verifier: &pb.Verifier{
@@ -285,8 +285,8 @@ func TestToLogEntry(t *testing.T) {
 				Kind:       "hashedrekord",
 				ApiVersion: "0.0.2",
 				Spec: &pb.Spec{
-					Spec: &pb.Spec_HashedRekordV0_0_2{
-						HashedRekordV0_0_2: &pb.HashedRekordLogEntryV0_0_2{
+					Spec: &pb.Spec_HashedRekordV002{
+						HashedRekordV002: &pb.HashedRekordLogEntryV002{
 							Data: &v1.HashOutput{
 								Digest:    hexDecodeOrDie(t, hexEncodedDigest384),
 								Algorithm: v1.HashAlgorithm_SHA2_384,

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -178,7 +178,7 @@ func TestReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "hashedrekord", e.Kind)
 	assert.Equal(t, "0.0.2", e.ApiVersion)
-	hrEntry := e.Spec.GetHashedRekordV0_0_2()
+	hrEntry := e.Spec.GetHashedRekordV002()
 	assert.NotNil(t, hrEntry)
 
 	// Add a DSSE entry
@@ -215,7 +215,7 @@ func TestReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "dsse", e.Kind)
 	assert.Equal(t, "0.0.2", e.ApiVersion)
-	dsseEntry := e.Spec.GetDsseV0_0_2()
+	dsseEntry := e.Spec.GetDsseV002()
 	assert.NotNil(t, dsseEntry)
 
 	// Add a second identical entries immediately to check for deduplication
@@ -271,13 +271,13 @@ func genKeys() (*ecdsa.PrivateKey, []byte, error) {
 	return privKey, pubKey, nil
 }
 
-func newHashedRekordRequest(privKey *ecdsa.PrivateKey, pubKey []byte, idx uint64) (*pb.HashedRekordRequestV0_0_2, error) {
+func newHashedRekordRequest(privKey *ecdsa.PrivateKey, pubKey []byte, idx uint64) (*pb.HashedRekordRequestV002, error) {
 	digest := artifactDigest(idx)
 	sig, err := ecdsa.SignASN1(rand.Reader, privKey, digest)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.HashedRekordRequestV0_0_2{
+	return &pb.HashedRekordRequestV002{
 		Signature: &pb.Signature{
 			Content: sig,
 			Verifier: &pb.Verifier{
@@ -313,12 +313,12 @@ func newDSSEEnvelope(privKey *ecdsa.PrivateKey) (*pbdsse.Envelope, error) {
 	return dsset.ToProto(envelope)
 }
 
-func newDSSERequest(privKey *ecdsa.PrivateKey, pubKey []byte) (*pb.DSSERequestV0_0_2, error) {
+func newDSSERequest(privKey *ecdsa.PrivateKey, pubKey []byte) (*pb.DSSERequestV002, error) {
 	envelope, err := newDSSEEnvelope(privKey)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.DSSERequestV0_0_2{
+	return &pb.DSSERequestV002{
 		Envelope: envelope,
 		Verifiers: []*pb.Verifier{
 			{
@@ -333,7 +333,7 @@ func newDSSERequest(privKey *ecdsa.PrivateKey, pubKey []byte) (*pb.DSSERequestV0
 	}, nil
 }
 
-func assertHashedRekordTLE(t *testing.T, tle *pbs.TransparencyLogEntry, initialTreeSize, numNewEntries uint64, logID []byte, verifier signednote.Verifier, hr *pb.HashedRekordRequestV0_0_2) {
+func assertHashedRekordTLE(t *testing.T, tle *pbs.TransparencyLogEntry, initialTreeSize, numNewEntries uint64, logID []byte, verifier signednote.Verifier, hr *pb.HashedRekordRequestV002) {
 	assert.NotNil(t, tle)
 
 	// Check server does not set deprecated fields
@@ -359,14 +359,14 @@ func assertHashedRekordTLE(t *testing.T, tle *pbs.TransparencyLogEntry, initialT
 	assert.NoError(t, err)
 	assert.Equal(t, "hashedrekord", e.Kind)
 	assert.Equal(t, "0.0.2", e.ApiVersion)
-	hrEntry := e.Spec.GetHashedRekordV0_0_2()
+	hrEntry := e.Spec.GetHashedRekordV002()
 	assert.NotNil(t, hrEntry)
 	assert.Equal(t, hrEntry.Signature, hr.Signature)
 	assert.Equal(t, hrEntry.Data.Algorithm, v1.HashAlgorithm_SHA2_256)
 	assert.Equal(t, hrEntry.Data.Digest, hr.Digest)
 }
 
-func assertDSSETLE(t *testing.T, tle *pbs.TransparencyLogEntry, index uint64, logID []byte, verifier signednote.Verifier, dr *pb.DSSERequestV0_0_2) {
+func assertDSSETLE(t *testing.T, tle *pbs.TransparencyLogEntry, index uint64, logID []byte, verifier signednote.Verifier, dr *pb.DSSERequestV002) {
 	assert.NotNil(t, tle)
 
 	// Check server does not set deprecated fields
@@ -390,7 +390,7 @@ func assertDSSETLE(t *testing.T, tle *pbs.TransparencyLogEntry, index uint64, lo
 	assert.NoError(t, err)
 	assert.Equal(t, "dsse", e.Kind)
 	assert.Equal(t, "0.0.2", e.ApiVersion)
-	dsseEntry := e.Spec.GetDsseV0_0_2()
+	dsseEntry := e.Spec.GetDsseV002()
 	assert.NotNil(t, dsseEntry)
 	// Assert payload hash is as expected
 	assert.Equal(t, dsseEntry.PayloadHash.Algorithm, v1.HashAlgorithm_SHA2_256)


### PR DESCRIPTION
...V0_0_2 -> ...V002

See naming: https://protobuf.dev/programming-guides/style/#identifier

We were initially using this to avoid collisions, but those are theoretical and we can work around them. Additionally we now can identify collisions at the proto spec level rather than at generation time.

#### Summary
Clients will once again need to regenerate type code. @jku we probably also want to disable pydantic here in a followup?

#### Release Note

#### Documentation
