### PR TITLE
Create utility for generating Tink keysets

### DIFF
--- a/cmd/create-tink-keyset/app/root.go
+++ b/cmd/create-tink-keyset/app/root.go
@@ -1,0 +1,188 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdh"
+	"crypto/ed25519"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tink-crypto/tink-go-gcpkms/v2/integration/gcpkms"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	"github.com/tink-crypto/tink-go/v2/proto/tink_go_proto"
+	"github.com/tink-crypto/tink-go/v2/signature"
+	tinkecdsa "github.com/tink-crypto/tink-go/v2/signature/ecdsa"
+	tinked25519 "github.com/tink-crypto/tink-go/v2/signature/ed25519"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "create-tink-keyset",
+	Short: "Create a Tink keyset",
+	Long:  "Generate a Tink keyset to be used to sign checkpoints, encrypted with a provided KMS key. Only supported for GCP currently.",
+	Run: func(_ *cobra.Command, _ []string) {
+		if viper.GetString("key-template") == "" {
+			slog.Error("must provide --key-template for signing key algorithm")
+			os.Exit(1)
+		}
+		kekURI := viper.GetString("key-encryption-key-uri")
+		if kekURI == "" {
+			slog.Error("must provide --key-encryption-key-uri for the GCP KMS CryptoKey resource that encrypts the keyset")
+			os.Exit(1)
+		}
+		if !strings.HasPrefix(kekURI, "gcp-kms://") {
+			slog.Error("--key-encryption-key-uri only supports GCP and the URI must begin with gcp-kms://")
+			os.Exit(1)
+		}
+		if viper.GetString("out") == "" {
+			slog.Error("must provide --out for output path of keyset")
+			os.Exit(1)
+		}
+		if viper.GetString("public-key-out") == "" {
+			slog.Error("must provide --public-key-out for output path of public key")
+			os.Exit(1)
+		}
+
+		ctx := context.Background()
+
+		// Generate GCP KMS client
+		kmsClient, err := gcpkms.NewClientWithOptions(ctx, kekURI)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		kekAEAD, err := kmsClient.GetAEAD(kekURI)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		// Create keyset handle, which initializes the signing key based on the provided template
+		keyTemplate, ok := algToKeyTemplate[viper.GetString("key-template")]
+		if !ok {
+			slog.Error("unsupported key template provided")
+			os.Exit(1)
+		}
+		newHandle, err := keyset.NewHandle(keyTemplate)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		// Encrypt signing key and generate keyset
+		buf := new(bytes.Buffer)
+		writer := keyset.NewJSONWriter(buf)
+		if err := newHandle.Write(writer, kekAEAD); err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		f, err := os.Create(viper.GetString("out"))
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		defer f.Close()
+		_, err = f.Write(buf.Bytes())
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		// Generate PEM-encoded public key
+		publicHandle, err := newHandle.Public()
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		keyset, err := publicHandle.Primary()
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		var pemPubKey []byte
+		switch publicKey := keyset.Key().(type) {
+		case *tinked25519.PublicKey:
+			pemPubKey, err = cryptoutils.MarshalPublicKeyToPEM(ed25519.PublicKey(publicKey.KeyBytes()))
+			if err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+		case *tinkecdsa.PublicKey:
+			curve := algToCurve[viper.GetString("key-template")]
+			pubKey, err := curve.NewPublicKey(publicKey.PublicPoint())
+			if err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+			pemPubKey, err = cryptoutils.MarshalPublicKeyToPEM(pubKey)
+			if err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+		}
+		pubF, err := os.Create(viper.GetString("public-key-out"))
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+		defer pubF.Close()
+		_, err = pubF.Write(pemPubKey)
+		if err != nil {
+			slog.Error(err.Error())
+			os.Exit(1)
+		}
+
+		slog.Info("generated Tink keyset")
+	},
+}
+
+var algToKeyTemplate = map[string]*tink_go_proto.KeyTemplate{
+	"ED25519":           signature.ED25519KeyTemplate(),
+	"ECDSA_P256":        signature.ECDSAP256KeyTemplate(),
+	"ECDSA_P384_SHA384": signature.ECDSAP384SHA384KeyTemplate(),
+	"ECDSA_P521":        signature.ECDSAP521KeyTemplate(),
+}
+
+var algToCurve = map[string]ecdh.Curve{
+	"ECDSA_P256":        ecdh.P256(),
+	"ECDSA_P384_SHA384": ecdh.P384(),
+	"ECDSA_P521":        ecdh.P521(),
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.Flags().String("key-template", "", "tink key template for the signing algorithm. Valid values are ED25519, ECDSA_P256, ECDSA_P384_SHA384, and ECDSA_P521")
+	rootCmd.Flags().String("key-encryption-key-uri", "", "Resource URI for the KMS key that encrypts the keyset. Only GCP is supported, and the URI must match gcp-kms://projects/*/locations/*/keyRings/*/cryptoKeys/*")
+	rootCmd.Flags().String("out", "", "output path for the encrypted keyset")
+	rootCmd.Flags().String("public-key-out", "", "output path for the PEM-encoded public key")
+
+	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/create-tink-keyset/main.go
+++ b/cmd/create-tink-keyset/main.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/sigstore/rekor-tiles/cmd/create-tink-keyset/app"
+
+func main() {
+	app.Execute()
+}


### PR DESCRIPTION
tinkey requires a Java runtime environment and doesn't support outputting PEM-encoded public keys. Threw together this utility to generate keysets and output the keyset's primary key. This will be used when spinning up new log shards to create key material.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
