### PR TITLE
Update clients doc for DSSE verification

### DIFF
--- a/CLIENTS.md
+++ b/CLIENTS.md
@@ -188,6 +188,14 @@ to parse an entry:
    bundle, but will have the canonicalized body. A monitor must use the `kind` and
    `apiVersion` to parse `spec`.
 
+#### DSSE
+
+For DSSE entries, the entry payload hash will always be SHA-256, regardless of
+the signature hashing algorithm specified in the key details. If non-default
+signing key algorithms (e.g. not ECDSA-P256) are supported, when verifying an entry,
+clients will need to handle computing the digest of the payload using SHA-256
+and computing the digest to verify based on the key details.
+
 ### Certificate and Public Key Verifiers
 
 Rekor v2 only supports signature verification using a certificate or a


### PR DESCRIPTION
The payload hash for a DSSE entry is always SHA-256. This was done to avoid needing a selection algorithm to pick a digest when multiple signature algorithms are used.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
