### PR TITLE
Catch pushback error

### DIFF
--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -125,6 +125,9 @@ func (s *Server) CreateEntry(ctx context.Context, req *pb.CreateEntryRequest) (*
 	}
 	entry := ttessera.NewEntry(canonicalized)
 	tle, err := s.storage.Add(ctx, entry)
+	if errors.Is(err, ttessera.ErrPushback) {
+		return nil, status.Errorf(codes.Unavailable, "reached max pushback; retry")
+	}
 	if errors.As(err, &tessera.DuplicateError{}) {
 		return nil, status.Error(codes.AlreadyExists, err.Error())
 	}


### PR DESCRIPTION
Catch the error if `--pushback-max-outstanding` requests is reached so that the client can wait and retry.

Noticed while reviewing the code base as part of #370 that this error wasn't being handled as [shown in the tessera examples](https://github.com/transparency-dev/tessera/blob/72c95603719317e660ad50f29facc99c13263b3e/cmd/conformance/gcp/main.go#L103-L107).

I wasn't able to fully test this due to https://github.com/transparency-dev/tessera/issues/731.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
