### PR TITLE
Update sharding with updated create-tink-keyset args

### DIFF
--- a/SHARDING.md
+++ b/SHARDING.md
@@ -360,7 +360,7 @@ Update the TrustedRoot for the new shard's key material:
       "baseUrl": "https://<year-revision>.rekor.(sigstore|sigstage).dev",
       "hashAlgorithm": "SHA2_256",
       "publicKey": {
-        "rawBytes": "<base64-encoded PKIX public key>",
+        "rawBytes": "<base64-encoded public key>",
         "keyDetails": "ED25519",
         "validFor": {
           "start": "<UTC timestamp for when shard was spun up>"

--- a/SHARDING.md
+++ b/SHARDING.md
@@ -136,20 +136,24 @@ Request a review from an infrastructure maintainer and merge.
 
 ```
 go run ./cmd/create-tink-keyset \
+  --origin <log origin, e.g. schemeless URL>
   --key-template ED25519 \
   --out enc-keyset.cfg \
   --key-encryption-key-uri gcp-kms://projects/<project name>/locations/<region>/keyRings/<key-ring>/cryptoKeys/checkpoint-signer-key-encryption-key \
-  --public-key-out public.pem
+  --public-key-out public.b64
+  --key-id-out keyid.b64
 ```
 
 Example:
 
 ```
 go run ./cmd/create-tink-keyset \
+  --origin log2026-1.rekor.sigstore.dev
   --key-template ED25519 \
   --out enc-keyset.cfg \
   --key-encryption-key-uri gcp-kms://projects/projectsigstore-staging/locations/global/keyRings/log2026-1-rekor-tiles-keyring/cryptoKeys/checkpoint-signer-key-encryption-key \
-  --public-key-out public.pem
+  --public-key-out public.b64
+  --key-id-out keyid.b64
 ```
 
 If there's an error that mentions `invalid_grant`, make sure you've run `gcloud auth application-default login`.
@@ -159,7 +163,7 @@ Note we won't use [tinkey](https://developers.google.com/tink/tinkey-overview#in
 that requires a Java runtime environment and won't output the public key.
 
 Save the output file `enc-keyset.cfg`, which will be used as a value in the Helm chart,
-and `public.pem`, which will be distributed in the TUF repo.
+and `public.b64` and `keyid.b64`, which will be distributed in the TUF repo.
 
 6. Revoke IAM access by reverting the PR and removing `google_kms_key_ring_iam_member`, and run `plan` and `apply`.
 
@@ -331,11 +335,17 @@ overly precise, and can be updated in a future TUF signing event.
 
 ### Get shard public key
 
-You should have the log public key saved in `public.pem` from when you generated the key.
+You should have the log public key saved in `public.b64` from when you generated the key,
+and the log's checkpoint key ID in `keyid.b64`.
 If you don't have the public key, look at the service logs to find the public key, which
-is logged on service startup.
+is logged on service startup. If you don't have the key ID, you can use
+[this script](https://go.dev/play/p/oiE6LjeqLnj) to generate the ID given the key.
 
-The key is PEM-encoded. Remove the PEM header and footer and remove all newline characters to get the base64-encoded PKIX public key.
+The key and ID are formatted such that you just need to copy them into a new
+instance in the TrustedRoot.
+
+// TODO: Give guidance on TrustedRoot and SigningConfig ordering
+// once https://github.com/sigstore/protobuf-specs/issues/729 is resolved
 
 ### Update TrustedRoot
 
@@ -350,14 +360,14 @@ Update the TrustedRoot for the new shard's key material:
       "baseUrl": "https://<year-revision>.rekor.(sigstore|sigstage).dev",
       "hashAlgorithm": "SHA2_256",
       "publicKey": {
-        "rawBytes": "base64-encoded DER public key",
+        "rawBytes": "<base64-encoded PKIX public key>",
         "keyDetails": "ED25519",
         "validFor": {
           "start": "<UTC timestamp for when shard was spun up>"
         }
       },
       "logId": {
-        "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+        "keyId": "<base64-encoded checkpoint key ID>"
       }
     },
     // previous shard


### PR DESCRIPTION
create-tink-keyset now outputs both the checkpoint key ID and the public key formatted exactly as the trusted root expects them.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
