### PR TITLE
Rename metrics

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -63,44 +63,44 @@ var _initMetricsFunc = sync.OnceValue[*metrics](func() *metrics {
 	f := promauto.With(m.reg)
 
 	m.newHashedRekordEntries = f.NewCounter(prometheus.CounterOpts{
-		Name: "rekor_new_hashedrekord_entries",
+		Name: "rekor_v2_new_hashedrekord_entries",
 		Help: "The total number of new dsse log entries",
 	})
 
 	m.newDsseEntries = f.NewCounter(prometheus.CounterOpts{
-		Name: "rekor_new_dsse_entries",
+		Name: "rekor_v2_new_dsse_entries",
 		Help: "The total number of new dsse log entries",
 	})
 
 	// grpc_packet_part should always be "payload" but we can measure "header" or "trailer" in the future
 	// if we so desire
 	m.grpcRequestSize = f.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "grpc_api_request_size",
+		Name: "rekor_v2_grpc_api_request_size",
 		Help: "API Request size on GRPC calls",
 	}, []string{"grpc_service", "grpc_method", "grpc_packet_part"})
 
 	m.httpLatency = f.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "rekor_http_api_latency",
+		Name: "rekor_v2_http_api_latency",
 		Help: "API Latency on HTTP calls",
 	}, []string{"code", "method"})
 
 	m.httpRequestsCount = f.NewCounterVec(prometheus.CounterOpts{
-		Name: "rekor_http_requests_total",
+		Name: "rekor_v2_http_requests_total",
 		Help: "Count all HTTP requests",
 	}, []string{"code", "method"})
 
 	m.httpRequestSize = f.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "rekor_http_api_request_size",
+		Name: "rekor_v2_http_api_request_size",
 		Help: "API Request size on HTTP calls",
 	}, []string{"code", "method"})
 
 	m.panicsTotal = f.NewCounter(prometheus.CounterOpts{
-		Name: "grpc_req_panics_recovered_total",
+		Name: "rekor_v2_grpc_req_panics_recovered_total",
 		Help: "Total number of gRPC requests recovered from internal panic.",
 	})
 
 	m.inclusionProofFailureCount = f.NewCounter(prometheus.CounterOpts{
-		Name: "rekor_inclusion_proof_failure_total",
+		Name: "rekor_v2_inclusion_proof_failure_total",
 		Help: "Total number of inclusion proof verification failures, which should always be zero. Likely catastrophic failure if not zero.",
 	})
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -52,14 +52,14 @@ func TestServe_httpMetricsSmoke(t *testing.T) {
 	// we ping healthz in our MockServer that will initialize some http stats for us. On a raw
 	// server with no requests ever recorded, rekor_http_* statistics may be uninitialized
 	expectedMetrics := []string{
-		"rekor_new_hashedrekord_entries",
-		"rekor_new_dsse_entries",
+		"rekor_v2_new_hashedrekord_entries",
+		"rekor_v2_new_dsse_entries",
 		"build_info",
-		"rekor_http_api_latency",
-		"rekor_http_requests_total",
-		"rekor_http_api_request_size",
-		"grpc_req_panics_recovered_total",
-		"grpc_api_request_size",
+		"rekor_v2_http_api_latency",
+		"rekor_v2_http_requests_total",
+		"rekor_v2_http_api_request_size",
+		"rekor_v2_grpc_req_panics_recovered_total",
+		"rekor_v2_grpc_api_request_size",
 		"grpc_server_started_total",    // should imply we have the default set of grpc server metrics
 		"grpc_server_handling_seconds", // should imply we have the default set of latency stats on grpc servers
 		"promhttp_metric_handler",      // should imply we have the default set of promhttp metrics


### PR DESCRIPTION
Rename metrics to be clear that these are generated by Rekor v2. Although the names of these metrics were not colliding with any generated by Rekor v1, the naming was confusing when using Metrics Explorer.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
