### PR TITLE
workflows: Streamline release

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -20,8 +20,7 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
+  workflow_call:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -46,9 +45,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-
-    # Require deployment review only for tagged builds
-    environment: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || 'ci-container' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Create release
+name: Create release, push container image
 
 on:
   push:
@@ -27,17 +27,19 @@ concurrency:
 permissions: {}
 
 jobs:
+  approval:
+    # Require deployment review
+    environment: release
+
   release:
     name: Create GitHub release
     runs-on: ubuntu-latest
+    needs: approval
 
     permissions:
       contents: write
       attestations: write
       id-token: write
-
-    # Require deployment review
-    environment: release
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -72,3 +74,9 @@ jobs:
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: ./dist/rekor-server-*
+
+  build-container:
+    name: Build and push container image
+    uses: ./.github/workflows/build_container.yml
+    secrets: inherit
+    needs: approval


### PR DESCRIPTION
Currently releasing requires separate approval for both release and the docker image upload
* Make build_container.yml not run on tag push, but make it callable from release.yml
* Add build-container job into release.yml
* Add approval job to release.yml (needed by release and build-container)

This way build_container does not need an environment check at all:
* either it is running on push to main (in which case it won't push an image)
* or it is running by workflow_call and expects the caller to do the check (as release.yml does)


---

Fixes #498, maybe. Obviously I can't really test this in any way... But it looks like it could work. 

CC @haydentherapper 