### PR TITLE
sharding: Add note about omitting bucket ID

### DIFF
--- a/SHARDING.md
+++ b/SHARDING.md
@@ -61,6 +61,9 @@ will create the required resources and monitoring.
 Note: You should omit `key_name`, which will be set to a default value of
 `checkpoint-signer-key-encryption-key`.
 
+Note: You should omit `bucket_id_length`, which will append a random UUID to the bucket
+name to make it unguessable, so that read traffic must go through the load balancer.
+
 Modules should be named based on the year and how many shards
 have been created in the year. For example, the module should
 be named `tiles_tlog_log2026_1` for the first shard in 2026. We'll


### PR DESCRIPTION
Accidentally left this in when creating the third testing shard. Buckets going forward will have a random ID appended to them.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
