### PR TITLE
remove sleep from production container

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -37,7 +37,6 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags "${SER
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0 AS deploy
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
-COPY --from=builder /usr/bin/sleep /usr/bin/sleep
 # Set the binary as the entrypoint of the container
 CMD ["rekor-server", "serve"]
 


### PR DESCRIPTION
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#LifecycleHandler:~:text=Defaults%20to%20HTTP.-,sleep%20(SleepAction),-Sleep%20represents%20a

this can be done from the kubelet VS invoking a binary inside the container in k8s 1.29+