### PR TITLE
workflows: Revert to inheriting secrets in build_container.yml

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -21,9 +21,6 @@ on:
     branches:
       - main
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,8 @@ jobs:
 
   build-container:
     name: Build and push container image
-    uses: ./.github/workflows/build_container.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/build_container.yml # zizmor: ignore[secrets-inherit]
+    secrets: inherit
     needs: approval
     permissions:
       contents: read


### PR DESCRIPTION
Not inheriting secrets would be a best practice but turns out workflow argument name GITHUB_TOKEN is not allowed. Revert back to inheriting and add ignore annotation for zizmor:
* This is not a real security issue as the reused workflow is ours
* not inheriting (using a variable with different name) would make the workflow quite bit more complex
