### PR TITLE
Move uint/int validator to separate package

### DIFF
--- a/internal/safeint/safeint.go
+++ b/internal/safeint/safeint.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tessera
+package safeint
 
 import (
 	"fmt"

--- a/internal/safeint/safeint_test.go
+++ b/internal/safeint/safeint_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tessera
+package safeint
 
 import (
 	"fmt"

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
-	"github.com/sigstore/rekor-tiles/v2/internal/tessera"
+	"github.com/sigstore/rekor-tiles/v2/internal/safeint"
 	f_log "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
@@ -29,7 +29,7 @@ import (
 // VerifyInclusionProof verifies an entry's inclusion proof
 func VerifyInclusionProof(entry *pbs.TransparencyLogEntry, cp *f_log.Checkpoint) error { //nolint: revive
 	leafHash := rfc6962.DefaultHasher.HashLeaf(entry.CanonicalizedBody)
-	index, err := tessera.NewSafeInt64(entry.LogIndex)
+	index, err := safeint.NewSafeInt64(entry.LogIndex)
 	if err != nil {
 		return fmt.Errorf("invalid index: %w", err)
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -35,7 +35,7 @@ import (
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	pbdsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
-	"github.com/sigstore/rekor-tiles/v2/internal/tessera"
+	"github.com/sigstore/rekor-tiles/v2/internal/safeint"
 	"github.com/sigstore/rekor-tiles/v2/pkg/client/read"
 	"github.com/sigstore/rekor-tiles/v2/pkg/client/write"
 	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
@@ -194,7 +194,7 @@ func TestReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assertDSSETLE(t, tle, initialTreeSize+numNewEntries-1, logID, noteVerifier, dr)
 
-	safeLogSize, err := tessera.NewSafeInt64(tle.InclusionProof.TreeSize)
+	safeLogSize, err := safeint.NewSafeInt64(tle.InclusionProof.TreeSize)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This avoids pulling in large dependencies into the public verify package.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
