### PR TITLE
Include log index as response header when duplicate is detected

### DIFF
--- a/internal/tessera/tessera.go
+++ b/internal/tessera/tessera.go
@@ -47,6 +47,10 @@ func (e DuplicateError) Error() string {
 	return fmt.Sprintf("an equivalent entry already exists in the transparency log with index %d", e.index)
 }
 
+func (e DuplicateError) Index() uint64 {
+	return e.index
+}
+
 type InclusionProofVerificationError struct {
 	index uint64
 	err   error


### PR DESCRIPTION
If a duplicate entry is detected during a request, the server returns a 409 with an error message that contains the log index. To avoid clients needing to know the structure of this error message, the server will now return a custom header "x-log-index" with the log index value. A client can use this log index to retrieve the entry from the tiled entry bundle and compute an inclusion proof from the tiles.

An alternative approach to solving this would be to just not return 409 errors and instead return the duplicate content. This would mask whether or not an entry is new content. This might be acceptable to clients, but to give them choice on how to respond to duplicates, we'll continue to serve 409 errors.

Fixes https://github.com/sigstore/rekor-tiles/issues/620

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
