### PR TITLE
Add argument to make ko-local for handling different storage backends

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: container
         run: |
-          make ko-local
+          make ko-local STORAGE_BACKEND=${{ matrix.storage }}
           docker run --rm $(cat rekorImagerefs-${{ matrix.storage }}) version
 
   unit-tests:

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ test: ## Run all tests
 ko-local: ## Build container images locally using ko
 	KO_DOCKER_REPO=ko.local LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	ko publish --base-import-paths \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs rekorImagerefs-gcp \
-		github.com/sigstore/rekor-tiles/v2/cmd/rekor-server/gcp
+		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs rekorImagerefs-$(STORAGE_BACKEND) \
+		github.com/sigstore/rekor-tiles/v2/cmd/rekor-server/$(STORAGE_BACKEND)
 
 # generate Go protobuf code
 protos:

--- a/internal/tessera/gcp/gcp.go
+++ b/internal/tessera/gcp/gcp.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/release-utils/version"
 )
 
-// DriverConfiguration contains storage-specific configuration for each supported storage backend.
+// DriverConfiguration contains storage-specific configuration for the GCP storage backend.
 type DriverConfiguration struct {
 	// Server origin
 	Hostname string
@@ -44,20 +44,20 @@ type DriverConfiguration struct {
 	ASPushbackThreshold uint
 }
 
-// NewDriver creates a Tessera driver and optional persistent antispam for a given storage backend.
+// NewDriver creates a Tessera driver and optional persistent antispam for the GCP storage backend.
 func NewDriver(ctx context.Context, config DriverConfiguration) (tessera.Driver, tessera.Antispam, error) {
 	if config.GCPBucket == "" || config.GCPSpannerDB == "" {
 		return nil, nil, fmt.Errorf("required flags missing to initialize Tessera driver")
 	}
 
-	driver, err := NewGCPDriver(ctx, config.GCPBucket, config.GCPSpannerDB, config.Hostname)
+	driver, err := newGCPDriver(ctx, config.GCPBucket, config.GCPSpannerDB, config.Hostname)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize GCP driver: %v", err.Error())
 	}
 
 	var persistentAntispam tessera.Antispam
 	if config.PersistentAntispam {
-		as, err := NewGCPAntispam(ctx, config.GCPSpannerDB, config.ASMaxBatchSize, config.ASPushbackThreshold)
+		as, err := newGCPAntispam(ctx, config.GCPSpannerDB, config.ASMaxBatchSize, config.ASPushbackThreshold)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize GCP antispam: %v", err.Error())
 		}
@@ -67,8 +67,8 @@ func NewDriver(ctx context.Context, config DriverConfiguration) (tessera.Driver,
 	return driver, persistentAntispam, nil
 }
 
-// NewGCPDriver returns a GCP Tessera Driver for the given bucket and spanner URI.
-func NewGCPDriver(ctx context.Context, bucket, spannerDB, hostname string) (tessera.Driver, error) {
+// newGCPDriver returns a GCP Tessera Driver for the given bucket and spanner URI.
+func newGCPDriver(ctx context.Context, bucket, spannerDB, hostname string) (tessera.Driver, error) {
 	userAgent := userAgent(hostname)
 	gcsClient, err := gcs.NewClient(ctx, gcs.WithJSONReads(), option.WithUserAgent(userAgent))
 	if err != nil {
@@ -91,8 +91,8 @@ func NewGCPDriver(ctx context.Context, bucket, spannerDB, hostname string) (tess
 	return driver, nil
 }
 
-// NewGCPAntispam initializes a Spanner database to store recent entries
-func NewGCPAntispam(ctx context.Context, spannerDb string, maxBatchSize, pushbackThreshold uint) (tessera.Antispam, error) {
+// newGCPAntispam initializes a Spanner database to store recent entries.
+func newGCPAntispam(ctx context.Context, spannerDb string, maxBatchSize, pushbackThreshold uint) (tessera.Antispam, error) {
 	asOpts := antispam.AntispamOpts{
 		MaxBatchSize:      maxBatchSize,
 		PushbackThreshold: pushbackThreshold,

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,8 @@
 
 ## Running the End to End tests
 
+### GCP binary
+
 Start the Docker containers from the top level directory:
 
 ```sh
@@ -11,11 +13,11 @@ docker compose -f compose.yml up -d --build --wait --wait-timeout 60
 Run the tests:
 
 ```sh
-go test -v -tags=e2e ./tests/
+go test -v -tags=e2e -run TestGCP ./tests/
 ```
 
 When finished, you can clean up the Docker containers if desired:
 
 ```sh
-docker compose down
+docker compose -f compose.yml down --volumes
 ```


### PR DESCRIPTION
When creating another storage backend, I realized that we need to parameterize make ko-local rather than run multiple ko publish commands.

Also a little cleanup for the GCP backend: Updated the e2e test readme, unexported driver initialization functions (not a breaking change, they're under internal).

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
