### PR TITLE
Add default backend for make ko-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ SERVER_LDFLAGS=$(REKOR_LDFLAGS)
 
 GOBIN = $(abspath ./tools/bin)
 
+STORAGE_BACKEND ?= gcp
+
 lint:
 	go tool addlicense -l apache -c "The Sigstore Authors" -ignore "third_party/**" -v *
 	go tool goimports -w $(SRC)
@@ -85,8 +87,8 @@ test: ## Run all tests
 ko-local: ## Build container images locally using ko, defaulting to the GCP container
 	KO_DOCKER_REPO=ko.local LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	ko publish --base-import-paths \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs rekorImagerefs-${STORAGE_BACKEND:-gcp} \
-		github.com/sigstore/rekor-tiles/v2/cmd/rekor-server/${STORAGE_BACKEND:-gcp}
+		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs rekorImagerefs-$(STORAGE_BACKEND) \
+		github.com/sigstore/rekor-tiles/v2/cmd/rekor-server/$(STORAGE_BACKEND)
 
 # generate Go protobuf code
 protos:


### PR DESCRIPTION
Following up on a comment I missed, this makes sure we can still run make ko-local without an argument.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
