### PR TITLE
Provide local proxy to mimic public instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,40 @@ Run `docker compose up --build --wait` to start the service along with emulated 
 Run `docker compose down` to turn down the service, or `docker compose down --volumes` to turn down the service and delete
 persisted tiles.
 
+### Local deployment with nginx
+
+To deploy rekor-tiles locally with an nginx reverse proxy (serving on port 80):
+
+1. Add `rekor-local` to your hosts file:
+
+   ```bash
+   # Linux/macOS
+   echo "127.0.0.1 rekor-local" | sudo tee -a /etc/hosts
+
+   # Windows (run as Administrator)
+   echo 127.0.0.1 rekor-local >> C:\Windows\System32\drivers\etc\hosts
+   ```
+
+2. Start the services with the `local` profile:
+
+   ```bash
+   docker compose --profile local up --build --wait
+   ```
+
+3. Verify the deployment:
+
+   ```bash
+   curl http://rekor-local/checkpoint
+   ```
+
+   You should see a checkpoint with signatures from both `rekor-local` and the witness.
+
+4. To stop the services:
+
+   ```bash
+   docker compose --profile local down --volumes
+   ```
+
 ### Making a request
 
 Follow the [client documentation](https://github.com/sigstore/rekor-tiles/blob/main/CLIENTS.md#rekor-v2-the-bash-way)

--- a/compose.yml
+++ b/compose.yml
@@ -117,6 +117,23 @@ services:
     ports:
       - "8100:8100"
 
+  nginx:
+    profiles:
+      - local
+    image: nginx:1.29.4@sha256:c881927c4077710ac4b1da63b83aa163937fb47457950c267d92f7e4dedf4aec
+    volumes:
+      - ./nginx/rekor.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      rekor:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
 # Launch with `docker compose up rekor-debug`
 # or  `docker compose up rekor-debug --watch`.
 # This service runs with the dlv debugger already in the Dockerfile.

--- a/nginx/rekor.conf
+++ b/nginx/rekor.conf
@@ -1,0 +1,44 @@
+server {
+    listen 80;
+
+    # /checkpoint -> GCS tile storage
+    location = /checkpoint {
+        proxy_pass http://gcs:7080/tiles/checkpoint;
+        proxy_set_header Host localhost:7080;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # /tile/* -> GCS tile storage
+    location /tile/ {
+        rewrite ^/tile/(.*)$ /tiles/tile/$1 break;
+        proxy_pass http://gcs:7080;
+        proxy_set_header Host localhost:7080;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # /log/entries -> rekor API (for adding entries)
+    location = /log/entries {
+        proxy_pass http://rekor:3000/api/v2/log/entries;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Content-Type $content_type;
+    }
+
+    # Pass through healthz from rekor
+    location = /healthz {
+        proxy_pass http://rekor:3000/healthz;
+    }
+
+    # Pass through original /api/v2/* paths for backwards compatibility
+    location /api/v2/ {
+        proxy_pass http://rekor:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Default: proxy to GCS tile storage
+    location / {
+        proxy_pass http://gcs:7080/tiles/;
+        proxy_set_header Host localhost:7080;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
Not sure if it was just me, but I had troubles using a local rekor-v2 for local development and I had to use nginx to "mimic" the public instance like `https://log2025-alpha2.rekor.sigstage.dev`.

Does it make sense to have this upstream?