### PR TITLE
Set IntegratedTime in TransparencyLogEntry from storage.Add

### DIFF
--- a/internal/tessera/tessera.go
+++ b/internal/tessera/tessera.go
@@ -148,6 +148,16 @@ func (s *storage) Add(ctx context.Context, entry *tessera.Entry) (*rekor_pb.Tran
 		LogIndex:          idx.I(),
 		InclusionProof:    inclusionProof,
 		CanonicalizedBody: entry.Data(),
+		// Set IntegratedTime at the point the entry was sequenced and the
+		// inclusion proof was built. This function is synchronous on Tessera
+		// integration (s.addEntry awaits the awaiter; buildProof requires the
+		// integrated tile state), so time.Now() is the integration time. Per
+		// the protobuf-specs comment on TransparencyLogEntry.integrated_time,
+		// this field is the "time the entry was integrated into the log".
+		// Closes #285 follow-up (the integrated_time half of the
+		// "Complete returned TransparencyLogEntry" trio that PR #292 only
+		// partially landed).
+		IntegratedTime: time.Now().Unix(),
 	}, nil
 }
 

--- a/internal/tessera/tessera_test.go
+++ b/internal/tessera/tessera_test.go
@@ -96,6 +96,40 @@ gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
 	}
 }
 
+// TestAddSetsIntegratedTime guards against the regression where
+// TransparencyLogEntry.IntegratedTime is left at the proto default (0) — the
+// gap behind issue #285 that PR #292 only partially closed. Verifies the
+// returned value is a plausible recent Unix timestamp.
+func TestAddSetsIntegratedTime(t *testing.T) {
+	ctx := context.Background()
+	tileHash := hexDecodeOrDie(t, "81bfc09c412c04da53a1b0ddb94dce48d6a24e9ea58987f7d45a04e8007fb3ca")
+	readCheckpoint := func(_ context.Context) ([]byte, error) {
+		<-time.After(5 * time.Millisecond)
+		return []byte(`test.origin
+1
+gb/AnEEsBNpTobDduU3OSNaiTp6liYf31FoE6AB/s8o=
+
+— test.origin AAAAAW5vb3AKMQpnYi9BbkVFc0JOcFRvYkRkdVUzT1NOYWlUcDZsaVlmMzFGb0U2QUIvczhvPQo=`), nil
+	}
+	s := storage{
+		awaiter: tessera.NewPublicationAwaiter(ctx, readCheckpoint, 10*time.Millisecond),
+		readTileFn: func(_ context.Context, _, _ uint64, _ uint8) ([]byte, error) {
+			return tileHash, nil
+		},
+		addFn: func(_ context.Context, _ *tessera.Entry) tessera.IndexFuture {
+			return func() (tessera.Index, error) { return tessera.Index{Index: 0}, nil }
+		},
+	}
+	before := time.Now().Unix()
+	got, err := s.Add(ctx, tessera.NewEntry([]byte("stuff")))
+	after := time.Now().Unix()
+
+	assert.NoError(t, err)
+	assert.NotZero(t, got.IntegratedTime, "IntegratedTime must not be left at proto default")
+	assert.GreaterOrEqual(t, got.IntegratedTime, before)
+	assert.LessOrEqual(t, got.IntegratedTime, after)
+}
+
 func TestReadTile(t *testing.T) {
 	ctx := context.Background()
 	tileHash := hexDecodeOrDie(t, "81bfc09c412c04da53a1b0ddb94dce48d6a24e9ea58987f7d45a04e8007fb3ca")


### PR DESCRIPTION
Closes #788. Follows up on #285 — finishes the IntegratedTime half that PR #292 left behind.

## Summary

`internal/tessera/tessera.go::storage.Add` left `TransparencyLogEntry.IntegratedTime` at the proto default (0), serializing to `"integratedTime": "0"` in HTTP/JSON responses. Sigstore Bundle v0.3 consumers (cosign, sigstore-python, sigstore-js, custom verifiers) read this field to validate replay windows and timestamp witnessing; a 0 value either fails strict verification or silently bypasses time-bound checks.

`storage.Add` is synchronous on Tessera integration (`s.addEntry` awaits the `PublicationAwaiter`; `buildProof` requires the integrated tile state), so `time.Now().Unix()` at this point matches the protobuf-specs definition of "the time the log entry was integrated into the log".

## Background

Issue #285 tracked all three missing TransparencyLogEntry fields (`LogID`, `KindVersion`, `IntegratedTime`). PR #292 closed it by landing `LogID` (in `Server.CreateEntry`) and `KindVersion`, but `IntegratedTime` was never landed and the issue was closed prematurely. I filed #788 from the consumer side after observing `"integratedTime": "0"` in production bundles produced by v2.2.1.

## Change

```go
return &rekor_pb.TransparencyLogEntry{
    LogIndex:          idx.I(),
    InclusionProof:    inclusionProof,
    CanonicalizedBody: entry.Data(),
+   IntegratedTime:    time.Now().Unix(),
}, nil
```

`time` is already imported.

## Test plan

- [x] New `TestAddSetsIntegratedTime` bounds the returned value between `time.Now()` before and after `storage.Add` returns; verifies `IntegratedTime != 0`.
- [x] Existing `TestAdd` (success / integration_failed / duplicate_entry) still passes.
- [x] Full `go test ./...` passes (`internal/server`, `pkg/verify`, `pkg/client/write`, `pkg/note`, etc. all green).

## Release notes

Bundle consumers that previously had to compensate for `integrated_time = 0` (either by stamping client-side at submission or by treating the field as untrusted) can now rely on the server value.