### PR TITLE
Limit client response reads, set default timeouts, and validate digest sizes

### DIFF
--- a/pkg/client/read/read.go
+++ b/pkg/client/read/read.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/sigstore/rekor-tiles/v2/pkg/client"
 	rekornote "github.com/sigstore/rekor-tiles/v2/pkg/note"
@@ -27,6 +28,10 @@ import (
 	"github.com/transparency-dev/formats/log"
 	tclient "github.com/transparency-dev/tessera/client"
 	"golang.org/x/mod/sumdb/note"
+)
+
+const (
+	defaultTimeout = 30 * time.Second
 )
 
 // Client reads checkpoints, tiles, and entry bundles from the tile storage service.
@@ -63,9 +68,13 @@ func NewReader(readURL, origin string, verifier signature.Verifier, opts ...clie
 			TLSClientConfig: cfg.TLSConfig,
 		}
 	}
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
 	httpClient := &http.Client{
 		Transport: client.CreateRoundTripper(transport, cfg.UserAgent),
-		Timeout:   cfg.Timeout,
+		Timeout:   timeout,
 	}
 	tileClient, err := tclient.NewHTTPFetcher(baseURL, httpClient)
 	if err != nil {

--- a/pkg/client/write/write.go
+++ b/pkg/client/write/write.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
 
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	"github.com/sigstore/rekor-tiles/v2/pkg/client"
@@ -31,7 +32,9 @@ import (
 )
 
 const (
-	addPath = "/api/v2/log/entries"
+	addPath         = "/api/v2/log/entries"
+	maxResponseSize = 10 * 1024 * 1024 // 10MB
+	defaultTimeout  = 30 * time.Second
 )
 
 // Client writes entries to rekor.
@@ -60,9 +63,13 @@ func NewWriter(writeURL string, opts ...client.Option) (Client, error) {
 			TLSClientConfig: cfg.TLSConfig,
 		}
 	}
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
 	httpClient := &http.Client{
 		Transport: client.CreateRoundTripper(transport, cfg.UserAgent),
-		Timeout:   cfg.Timeout,
+		Timeout:   timeout,
 	}
 	return &writeClient{
 		baseURL: baseURL,
@@ -93,7 +100,7 @@ func (w *writeClient) Add(ctx context.Context, entry any) (*pbs.TransparencyLogE
 		return nil, fmt.Errorf("getting response: %w", err)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return nil, fmt.Errorf("reading response: %w", err)
 	}

--- a/pkg/client/write/write_test.go
+++ b/pkg/client/write/write_test.go
@@ -46,7 +46,7 @@ func TestNewWriter(t *testing.T) {
 			name: "no options",
 			expected: &writeClient{
 				baseURL: &url.URL{Scheme: "http", Host: "localhost:3003"},
-				client:  &http.Client{Transport: http.DefaultTransport},
+				client:  &http.Client{Transport: http.DefaultTransport, Timeout: 30 * time.Second},
 			},
 		},
 		{
@@ -56,7 +56,7 @@ func TestNewWriter(t *testing.T) {
 			},
 			expected: &writeClient{
 				baseURL: &url.URL{Scheme: "http", Host: "localhost:3003"},
-				client:  &http.Client{Transport: client.CreateRoundTripper(nil, "test")},
+				client:  &http.Client{Transport: client.CreateRoundTripper(nil, "test"), Timeout: 30 * time.Second},
 			},
 		},
 		{
@@ -278,4 +278,34 @@ func marshalJSONOrDie(t *testing.T, obj any) []byte {
 		t.Fatal(err)
 	}
 	return marshaledResp
+}
+
+func TestAdd_ResponseExceedsLimit(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			// Write 10MB + 1 byte
+			w.Write(make([]byte, 10*1024*1024+1))
+		}))
+	defer server.Close()
+
+	client, err := NewWriter(server.URL)
+	assert.NoError(t, err)
+
+	entry := &pb.HashedRekordRequestV002{
+		Signature: &pb.Signature{
+			Content: []byte("sig"),
+			Verifier: &pb.Verifier{
+				Verifier: &pb.Verifier_PublicKey{
+					PublicKey: &pb.PublicKey{RawBytes: []byte("key")},
+				},
+				KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+			},
+		},
+		Digest: []byte("digest"),
+	}
+
+	_, gotErr := client.Add(ctx, entry)
+	assert.Error(t, gotErr)
 }

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -49,7 +49,13 @@ func ToLogEntry(hr *pb.HashedRekordRequestV002, algorithmRegistry *signature.Alg
 		return nil, err
 	}
 
-	if err := verifySignature(hr, v, algDetails.GetHashType()); err != nil {
+	hashAlg := algDetails.GetHashType()
+	expectedSize := hashAlg.Size()
+	if len(hr.Digest) != expectedSize {
+		return nil, fmt.Errorf("digest length (%d) does not match expected size (%d) for algorithm %s", len(hr.Digest), expectedSize, hashAlg.String())
+	}
+
+	if err := verifySignature(hr, v, hashAlg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -322,6 +322,42 @@ func TestToLogEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "mismatched digest length (too short)",
+			hashedrekord: &pb.HashedRekordRequestV002{
+				Signature: &pb.Signature{
+					Content: b64DecodeOrDie(t, b64EncodedSignature),
+					Verifier: &pb.Verifier{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte(publicKey),
+							},
+						},
+						KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+					},
+				},
+				Digest: []byte{0xab},
+			},
+			expectErr: fmt.Errorf("digest length (1) does not match expected size (32) for algorithm SHA-256"),
+		},
+		{
+			name: "mismatched digest length (too long)",
+			hashedrekord: &pb.HashedRekordRequestV002{
+				Signature: &pb.Signature{
+					Content: b64DecodeOrDie(t, b64EncodedSignature),
+					Verifier: &pb.Verifier{
+						Verifier: &pb.Verifier_PublicKey{
+							PublicKey: &pb.PublicKey{
+								RawBytes: []byte(publicKey),
+							},
+						},
+						KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+					},
+				},
+				Digest: bytes.Repeat([]byte{0xab}, 33),
+			},
+			expectErr: fmt.Errorf("digest length (33) does not match expected size (32) for algorithm SHA-256"),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This change adds a few best practices as suggested by Gemini.

* Bounded the write client's server response body reading to a maximum of 10MB.
* Set a default HTTP client request timeout of 30 seconds.
* Validated HashedRekord request digest lengths against the output size of the declared hash algorithm.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
