### PR TITLE
workflows: Bump codecov to fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           CODECOV_TOKEN=$(echo $TOKEN_RESPONSE | jq -r .value)
           echo "CODECOV_TOKEN=$CODECOV_TOKEN" >> "$GITHUB_ENV"
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           env_vars: OS
           fail_ci_if_error: true


### PR DESCRIPTION
This should fix the issue of codecov upload failing with
  _Could not verify signature. Please contact Codecov if problem continues_
(see all recent CI runs)