### PR TITLE
Drop removed flag for witness in e2e tests

### DIFF
--- a/aws-compose.yml
+++ b/aws-compose.yml
@@ -129,7 +129,6 @@ services:
       - "--db_file=/witness_data/witness.sqlite"
       - "--private_key_path=/witness_config/private.key"
       - "--additional_logs=/witness_config/config.yaml"
-      - "--poll_interval=0"
       - "--logtostderr"
       - "--v=2"
     restart: always

--- a/cloudsql-compose.yml
+++ b/cloudsql-compose.yml
@@ -126,7 +126,6 @@ services:
       - "--db_file=/witness_data/witness.sqlite"
       - "--private_key_path=/witness_config/private.key"
       - "--additional_logs=/witness_config/config.yaml"
-      - "--poll_interval=0"
       - "--logtostderr"
       - "--v=2"
     restart: always

--- a/compose.yml
+++ b/compose.yml
@@ -103,7 +103,6 @@ services:
       - "--db_file=/witness_data/witness.sqlite"
       - "--private_key_path=/witness_config/private.key"
       - "--additional_logs=/witness_config/config.yaml"
-      - "--poll_interval=0"
       - "--logtostderr"
       - "--v=2"
     restart: always

--- a/posix-compose.yml
+++ b/posix-compose.yml
@@ -76,7 +76,6 @@ services:
       - "--db_file=/witness_data/witness.sqlite"
       - "--private_key_path=/witness_config/private.key"
       - "--additional_logs=/witness_config/config.yaml"
-      - "--poll_interval=0"
       - "--logtostderr"
       - "--v=2"
     restart: always


### PR DESCRIPTION
This flag was removed since support for feeding checkpoints to the witnesses was dropped. We don't use this feature anyways.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
