### PR TITLE
Implement Identity-based Transparency Logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,8 @@ jobs:
         storage: [ {name: 'GCP', compose: 'compose.yml', test: 'TestGCPSpanner'},
                    {name: 'POSIX', compose: 'posix-compose.yml', test: 'TestPOSIX'},
                    {name: 'AWS', compose: 'aws-compose.yml', test: 'TestAWS'},
-                   {name: 'GCP Cloud SQL', compose: 'cloudsql-compose.yml', test: 'TestGCPCloudSQL'} ]
+                   {name: 'GCP Cloud SQL', compose: 'cloudsql-compose.yml', test: 'TestGCPCloudSQL'},
+                   {name: 'Identity POSIX', compose: 'identity-posix-compose.yml', test: 'TestIdentityPOSIX'} ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/api/proto/rekor/v2/identity.proto
+++ b/api/proto/rekor/v2/identity.proto
@@ -32,6 +32,10 @@ message PublicKeyCredential {
     // The signature computed over the specification identifier, checksum, and context strings,
     // as defined by the c2sp.org/identity-transparency specification.
     bytes signature = 2 [(google.api.field_behavior) = REQUIRED];
+
+    // Optional context value to record alongside the message. Must be a SHA-256 digest.
+    // Must be signed as defined by the c2sp.org/identity-transparency specification.
+    bytes context = 3;
 }
 
 // A request to add an identity-based transparency log entry (v0.0.1)
@@ -42,7 +46,4 @@ message IdentityRequestV001 {
     
     // Must be a SHA-256 digest of data.
     bytes message = 3 [(google.api.field_behavior) = REQUIRED];
-    
-    // Optional context value. Must be a SHA-256 digest.
-    bytes context = 4;
 }

--- a/cmd/rekor-server/posix/app/serve.go
+++ b/cmd/rekor-server/posix/app/serve.go
@@ -44,165 +44,184 @@ var serveCmd = &cobra.Command{
 	Short: "start the Rekor server",
 	Long:  "start the Rekor server",
 	Run: func(cmd *cobra.Command, _ []string) {
-		ctx := cmd.Context()
-
-		logLevel := slog.LevelInfo
-		if err := logLevel.UnmarshalText([]byte(viper.GetString("log-level"))); err != nil {
-			slog.Error("invalid log-level specified; must be one of 'debug', 'info', 'error', or 'warn'")
-			os.Exit(1)
-		}
-		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
-
-		// tessera uses klog so pipe all klog messages to be written through slog
-		klog.SetSlogLogger(slog.Default())
-
-		slog.Info("starting rekor-server", "version", version.GetVersionInfo())
-
-		if viper.GetString("signer-filepath") == "" {
-			slog.Error("--signer-filepath must be set")
-			os.Exit(1)
-		}
-		signer, err := signerverifier.NewFileSignerVerifier(viper.GetString("signer-filepath"), viper.GetString("signer-password"))
-		if err != nil {
-			slog.Error("failed to initialize signer", "error", err)
-			os.Exit(1)
-		}
-		pubkey, err := signer.PublicKey()
-		if err != nil {
-			slog.Error("failed to get public key from signing key", "error", err)
-			os.Exit(1)
-		}
-		der, err := x509.MarshalPKIXPublicKey(pubkey)
-		if err != nil {
-			slog.Error("failed to marshal public key to DER", "error", err)
-			os.Exit(1)
-		}
-		slog.Info("Loaded signing key", "pubkey in base64 DER", base64.StdEncoding.EncodeToString(der))
-
-		appendOptions, err := tessera.NewAppendOptions(ctx, viper.GetString("hostname"), signer)
-		if err != nil {
-			slog.Error("failed to initialize append options", "error", err)
-			os.Exit(1)
-		}
-		// Compute log ID for TransparencyLogEntry, to be used by clients to look up
-		// the correct instance in a trust root. Log ID is equivalent to the non-truncated
-		// hash of the public key and origin per the signed-note C2SP spec.
-		pubKey, err := signer.PublicKey(options.WithContext(ctx))
-		if err != nil {
-			slog.Error("failed to get public key", "error", err)
-			os.Exit(1)
-		}
-		_, logID, err := note.KeyHash(viper.GetString("hostname"), pubKey)
-		if err != nil {
-			slog.Error("failed to get log ID", "error", err)
-			os.Exit(1)
-		}
-
-		readOnly := viper.GetBool("read-only")
-		var tesseraStorage tessera.Storage
-		shutdownFn := func(_ context.Context) error { return nil }
-		// if in read-only mode, don't start the appender, because we don't want new checkpoints being published.
-		if !readOnly {
-			driverConfig := posixDriver.DriverConfiguration{
-				StorageDir:          viper.GetString("storage-dir"),
-				PersistentAntispam:  viper.GetBool("persistent-antispam"),
-				ASMaxBatchSize:      viper.GetUint("antispam-max-batch-size"),
-				ASPushbackThreshold: viper.GetUint("antispam-pushback-threshold"),
-			}
-			tesseraDriver, persistentAntispam, err := posixDriver.NewDriver(ctx, driverConfig)
-			if err != nil {
-				slog.Error("failed to initialize driver", "error", err)
-				os.Exit(1)
-			}
-			appendOptions = tessera.WithLifecycleOptions(appendOptions, viper.GetUint("batch-max-size"), viper.GetDuration("batch-max-age"), viper.GetDuration("checkpoint-interval"), viper.GetUint("pushback-max-outstanding"))
-			appendOptions = tessera.WithAntispamOptions(appendOptions, persistentAntispam)
-			if wpf := viper.GetString("witness-policy-path"); wpf != "" {
-				f, err := os.ReadFile(wpf)
-				if err != nil {
-					slog.Error("failed to read witness policy file", "file", wpf, "error", err)
-					os.Exit(1)
-				}
-				appendOptions, err = tessera.WithWitnessing(appendOptions, f)
-				if err != nil {
-					slog.Error("failed to initialize witnessing", "error", err)
-					os.Exit(1)
-				}
-			}
-			tesseraStorage, shutdownFn, err = tessera.NewStorage(ctx, viper.GetString("hostname"), tesseraDriver, appendOptions)
-			if err != nil {
-				slog.Error("failed to initialize tessera storage", "error", err)
-				os.Exit(1)
-			}
-		}
-		algorithms := viper.GetStringSlice("client-signing-algorithms")
-		if viper.GetBool("identity-mode") {
-			if !cmd.Flags().Changed("client-signing-algorithms") {
-				algorithms = []string{"ed25519"}
-			}
-			for _, alg := range algorithms {
-				if alg != "ed25519" {
-					slog.Error(fmt.Sprintf("unsupported algorithm '%s' for identity log", alg))
-					os.Exit(1)
-				}
-			}
-		}
-
-		algorithmRegistry, err := algorithmregistry.AlgorithmRegistry(algorithms)
-		if err != nil {
-			slog.Error("failed to get algorithm registry", "error", err)
-			os.Exit(1)
-		}
-
-		var rekorServer any
-		if viper.GetBool("identity-mode") {
-			rekorServer = server.NewIdentityServer(tesseraStorage, readOnly, algorithmRegistry)
-		} else {
-			rekorServer = server.NewServer(tesseraStorage, readOnly, algorithmRegistry, logID)
-		}
-
-		server.Serve(
-			ctx,
-			server.NewHTTPConfig(
-				server.WithHTTPPort(viper.GetInt("http-port")),
-				server.WithHTTPHost(viper.GetString("http-address")),
-				server.WithHTTPTimeout(viper.GetDuration("server-timeout")),
-				server.WithHTTPMaxRequestBodySize(viper.GetInt("max-request-body-size")),
-				server.WithHTTPMetricsPort(viper.GetInt("http-metrics-port")),
-				server.WithHTTPTLSCredentials(viper.GetString("http-tls-cert-file"), viper.GetString("http-tls-key-file")),
-				server.WithGRPCTLSCredentials(viper.GetString("grpc-tls-cert-file")),
-			),
-			server.NewGRPCConfig(
-				server.WithGRPCPort(viper.GetInt("grpc-port")),
-				server.WithGRPCHost(viper.GetString("grpc-address")),
-				server.WithGRPCTimeout(viper.GetDuration("server-timeout")),
-				server.WithGRPCMaxMessageSize(viper.GetInt("max-request-body-size")),
-				server.WithGRPCLogLevel(logLevel, viper.GetBool("request-response-logging")),
-				server.WithTLSCredentials(viper.GetString("grpc-tls-cert-file"), viper.GetString("grpc-tls-key-file")),
-			),
-			viper.GetDuration("tlog-timeout"),
-			rekorServer,
-			shutdownFn,
-		)
+		runServer(cmd, false)
 	},
 }
 
-func init() {
-	if err := cli.Initialize(serveCmd); err != nil {
+var serveIdentityCmd = &cobra.Command{
+	Use:   "serve-identity",
+	Short: "start the Rekor identity usage server",
+	Long:  "start the Rekor identity usage server",
+	Run: func(cmd *cobra.Command, _ []string) {
+		runServer(cmd, true)
+	},
+}
+
+func runServer(cmd *cobra.Command, isIdentity bool) {
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+
+	ctx := cmd.Context()
+
+	logLevel := slog.LevelInfo
+	if err := logLevel.UnmarshalText([]byte(viper.GetString("log-level"))); err != nil {
+		slog.Error("invalid log-level specified; must be one of 'debug', 'info', 'error', or 'warn'")
+		os.Exit(1)
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
+
+	// tessera uses klog so pipe all klog messages to be written through slog
+	klog.SetSlogLogger(slog.Default())
+
+	slog.Info("starting rekor-server", "version", version.GetVersionInfo(), "identity_mode", isIdentity)
+
+	if viper.GetString("signer-filepath") == "" {
+		slog.Error("--signer-filepath must be set")
+		os.Exit(1)
+	}
+	signer, err := signerverifier.NewFileSignerVerifier(viper.GetString("signer-filepath"), viper.GetString("signer-password"))
+	if err != nil {
+		slog.Error("failed to initialize signer", "error", err)
+		os.Exit(1)
+	}
+	pubkey, err := signer.PublicKey()
+	if err != nil {
+		slog.Error("failed to get public key from signing key", "error", err)
+		os.Exit(1)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pubkey)
+	if err != nil {
+		slog.Error("failed to marshal public key to DER", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("Loaded signing key", "pubkey in base64 DER", base64.StdEncoding.EncodeToString(der))
+
+	appendOptions, err := tessera.NewAppendOptions(ctx, viper.GetString("hostname"), signer)
+	if err != nil {
+		slog.Error("failed to initialize append options", "error", err)
+		os.Exit(1)
+	}
+	// Compute log ID for TransparencyLogEntry, to be used by clients to look up
+	// the correct instance in a trust root. Log ID is equivalent to the non-truncated
+	// hash of the public key and origin per the signed-note C2SP spec.
+	pubKey, err := signer.PublicKey(options.WithContext(ctx))
+	if err != nil {
+		slog.Error("failed to get public key", "error", err)
+		os.Exit(1)
+	}
+	_, logID, err := note.KeyHash(viper.GetString("hostname"), pubKey)
+	if err != nil {
+		slog.Error("failed to get log ID", "error", err)
+		os.Exit(1)
+	}
+
+	readOnly := viper.GetBool("read-only")
+	var tesseraStorage tessera.Storage
+	shutdownFn := func(_ context.Context) error { return nil }
+	// if in read-only mode, don't start the appender, because we don't want new checkpoints being published.
+	if !readOnly {
+		driverConfig := posixDriver.DriverConfiguration{
+			StorageDir:          viper.GetString("storage-dir"),
+			PersistentAntispam:  viper.GetBool("persistent-antispam"),
+			ASMaxBatchSize:      viper.GetUint("antispam-max-batch-size"),
+			ASPushbackThreshold: viper.GetUint("antispam-pushback-threshold"),
+		}
+		tesseraDriver, persistentAntispam, err := posixDriver.NewDriver(ctx, driverConfig)
+		if err != nil {
+			slog.Error("failed to initialize driver", "error", err)
+			os.Exit(1)
+		}
+		appendOptions = tessera.WithLifecycleOptions(appendOptions, viper.GetUint("batch-max-size"), viper.GetDuration("batch-max-age"), viper.GetDuration("checkpoint-interval"), viper.GetUint("pushback-max-outstanding"))
+		appendOptions = tessera.WithAntispamOptions(appendOptions, persistentAntispam)
+		if wpf := viper.GetString("witness-policy-path"); wpf != "" {
+			f, err := os.ReadFile(wpf)
+			if err != nil {
+				slog.Error("failed to read witness policy file", "file", wpf, "error", err)
+				os.Exit(1)
+			}
+			appendOptions, err = tessera.WithWitnessing(appendOptions, f)
+			if err != nil {
+				slog.Error("failed to initialize witnessing", "error", err)
+				os.Exit(1)
+			}
+		}
+		tesseraStorage, shutdownFn, err = tessera.NewStorage(ctx, viper.GetString("hostname"), tesseraDriver, appendOptions)
+		if err != nil {
+			slog.Error("failed to initialize tessera storage", "error", err)
+			os.Exit(1)
+		}
+	}
+	algorithms := viper.GetStringSlice("client-signing-algorithms")
+	if isIdentity {
+		if !cmd.Flags().Changed("client-signing-algorithms") {
+			algorithms = []string{"ed25519"}
+		}
+		for _, alg := range algorithms {
+			if alg != "ed25519" {
+				slog.Error(fmt.Sprintf("unsupported algorithm '%s' for identity log", alg))
+				os.Exit(1)
+			}
+		}
+	}
+
+	algorithmRegistry, err := algorithmregistry.AlgorithmRegistry(algorithms)
+	if err != nil {
+		slog.Error("failed to get algorithm registry", "error", err)
+		os.Exit(1)
+	}
+
+	var rekorServer server.Registrar
+	if isIdentity {
+		rekorServer = server.NewIdentityServer(tesseraStorage, readOnly, algorithmRegistry)
+	} else {
+		rekorServer = server.NewServer(tesseraStorage, readOnly, algorithmRegistry, logID)
+	}
+
+	server.Serve(
+		ctx,
+		server.NewHTTPConfig(
+			server.WithHTTPPort(viper.GetInt("http-port")),
+			server.WithHTTPHost(viper.GetString("http-address")),
+			server.WithHTTPTimeout(viper.GetDuration("server-timeout")),
+			server.WithHTTPMaxRequestBodySize(viper.GetInt("max-request-body-size")),
+			server.WithHTTPMetricsPort(viper.GetInt("http-metrics-port")),
+			server.WithHTTPTLSCredentials(viper.GetString("http-tls-cert-file"), viper.GetString("http-tls-key-file")),
+			server.WithGRPCTLSCredentials(viper.GetString("grpc-tls-cert-file")),
+		),
+		server.NewGRPCConfig(
+			server.WithGRPCPort(viper.GetInt("grpc-port")),
+			server.WithGRPCHost(viper.GetString("grpc-address")),
+			server.WithGRPCTimeout(viper.GetDuration("server-timeout")),
+			server.WithGRPCMaxMessageSize(viper.GetInt("max-request-body-size")),
+			server.WithGRPCLogLevel(logLevel, viper.GetBool("request-response-logging")),
+			server.WithTLSCredentials(viper.GetString("grpc-tls-cert-file"), viper.GetString("grpc-tls-key-file")),
+		),
+		viper.GetDuration("tlog-timeout"),
+		rekorServer,
+		shutdownFn,
+	)
+}
+
+func addFlags(cmd *cobra.Command) {
+	if err := cli.Initialize(cmd); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}
 
 	// POSIX configs
-	serveCmd.Flags().String("storage-dir", "", "directory for tile and checkpoint storage for a POSIX log")
-	serveCmd.Flags().Bool("identity-mode", false, "run as an identity log server")
+	cmd.Flags().String("storage-dir", "", "directory for tile and checkpoint storage for a POSIX log")
 
 	// checkpoint signing configs
-	serveCmd.Flags().String("signer-filepath", "", "path to the signing key")
-	serveCmd.Flags().String("signer-password", "", "password to decrypt the signing key")
+	cmd.Flags().String("signer-filepath", "", "path to the signing key")
+	cmd.Flags().String("signer-password", "", "password to decrypt the signing key")
+}
 
-	if err := viper.BindPFlags(serveCmd.Flags()); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
+func init() {
+	addFlags(serveCmd)
 	rootCmd.AddCommand(serveCmd)
+
+	addFlags(serveIdentityCmd)
+	rootCmd.AddCommand(serveIdentityCmd)
 }

--- a/docs/openapi/rekor/v2/rekor_identity_service.swagger.json
+++ b/docs/openapi/rekor/v2/rekor_identity_service.swagger.json
@@ -127,11 +127,6 @@
           "type": "string",
           "format": "byte",
           "description": "Must be a SHA-256 digest of data."
-        },
-        "context": {
-          "type": "string",
-          "format": "byte",
-          "description": "Optional context value. Must be a SHA-256 digest."
         }
       },
       "title": "A request to add an identity-based transparency log entry (v0.0.1)",
@@ -151,6 +146,11 @@
           "type": "string",
           "format": "byte",
           "description": "The signature computed over the specification identifier, checksum, and context strings,\nas defined by the c2sp.org/identity-transparency specification."
+        },
+        "context": {
+          "type": "string",
+          "format": "byte",
+          "description": "Optional context value to record alongside the message. Must be a SHA-256 digest.\nMust be signed as defined by the c2sp.org/identity-transparency specification."
         }
       },
       "required": [

--- a/identity-posix-compose.yml
+++ b/identity-posix-compose.yml
@@ -1,0 +1,94 @@
+# Copyright 2026 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  rekor:
+    build:
+      context: .
+      target: deploy
+      args:
+        STORAGE_BACKEND: posix
+    command:
+    - "rekor-server"
+    - "serve-identity"
+    - "--http-address=0.0.0.0"
+    - "--grpc-address=0.0.0.0"
+    - "--hostname=rekor-local"
+    - "--storage-dir=/tmp/identityposixlog"
+    - "--signer-filepath=/pki/ed25519-priv-key.pem"
+    - "--checkpoint-interval=2s"
+    - "--log-level=debug"
+    - "--request-response-logging=true"
+    - "--persistent-antispam=true"
+    - "--witness-policy-path=/witness/policy.yaml"
+    ports:
+    - "3006:3000" # http port
+    - "3007:3001" # grpc port
+    - "2115:2112" # metrics port
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - curl http://localhost:3000/healthz | grep '{"status":"SERVING"}'
+      timeout: 30s
+      retries: 10
+      interval: 3s
+    volumes:
+    - ./tests/testdata/pki:/pki
+    - ./tests/testdata/witness:/witness
+    - identity_posix_storage:/tmp/identityposixlog
+    depends_on:
+      nginx:
+        condition: service_healthy
+      witness:
+        condition: service_healthy
+  nginx:
+    image: nginx:1.31.1@sha256:5aca99593157f4ae539a5dec1092a0ad8762f8e2eb1789085a13a0f5622369f6
+    volumes:
+      - identity_posix_storage:/usr/share/nginx/html
+    restart: always
+    ports:
+      - "8001:80"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost/"]
+      interval: 30s
+      retries: 10
+      timeout: 3s
+  witness:
+    build:
+      context: https://github.com/transparency-dev/witness.git#main
+      dockerfile: cmd/omniwitness/Dockerfile
+    volumes:
+      - witness_data:/witness_data:rw
+      - ./tests/testdata/witness:/witness_config
+    command:
+      - "--listen=:8100"
+      - "--db_file=/witness_data/witness.sqlite"
+      - "--private_key_path=/witness_config/private.key"
+      - "--additional_logs=/witness_config/config.yaml"
+      - "--logtostderr"
+      - "--v=2"
+      - "--rate_limit=100"
+    restart: always
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - wget --spider --tries=1 http://localhost:8081/metrics || exit 1
+      timeout: 30s
+      retries: 10
+      interval: 3s
+    ports:
+      - "8101:8100"
+volumes:
+  identity_posix_storage: {}
+  witness_data: {}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
-	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -52,11 +51,11 @@ import (
 type grpcServer struct {
 	*grpc.Server
 	serverEndpoint string
-	serverImpl     any
+	serverImpl     HTTPRegistrar
 }
 
 // newGRPCServer starts a new grpc server and registers the services.
-func newGRPCServer(config *GRPCConfig, server any) *grpcServer {
+func newGRPCServer(config *GRPCConfig, server Registrar) *grpcServer {
 	var opts []grpc.ServerOption
 
 	grpcPanicRecoveryHandler := func(p any) (err error) {
@@ -88,15 +87,8 @@ func newGRPCServer(config *GRPCConfig, server any) *grpcServer {
 
 	s := grpc.NewServer(opts...)
 
-	if r, ok := server.(pb.RekorServer); ok {
-		pb.RegisterRekorServer(s, r)
-	}
-	if i, ok := server.(pb.IdentityRekorServer); ok {
-		pb.RegisterIdentityRekorServer(s, i)
-	}
-	if h, ok := server.(grpc_health_v1.HealthServer); ok {
-		grpc_health_v1.RegisterHealthServer(s, h)
-	}
+	server.RegisterGRPC(s)
+	grpc_health_v1.RegisterHealthServer(s, server)
 
 	reflection.Register(s)
 

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -88,19 +87,10 @@ func newHTTPProxy(ctx context.Context, config *HTTPConfig, grpcServer *grpcServe
 		runtime.WithHealthzEndpoint(grpc_health_v1.NewHealthClient(cc)), // localhost:[port]/healthz
 	)
 
-	if _, ok := grpcServer.serverImpl.(pb.RekorServer); ok {
-		err = pb.RegisterRekorHandlerFromEndpoint(ctx, mux, grpcServer.serverEndpoint, opts)
-		if err != nil {
-			slog.Error("failed to register rekor handler", "error", err)
-			os.Exit(1)
-		}
-	}
-	if _, ok := grpcServer.serverImpl.(pb.IdentityRekorServer); ok {
-		err = pb.RegisterIdentityRekorHandlerFromEndpoint(ctx, mux, grpcServer.serverEndpoint, opts)
-		if err != nil {
-			slog.Error("failed to register identity handler", "error", err)
-			os.Exit(1)
-		}
+	err = grpcServer.serverImpl.RegisterHTTP(ctx, mux, grpcServer.serverEndpoint, opts)
+	if err != nil {
+		slog.Error("failed to register http handler", "error", err)
+		os.Exit(1)
 	}
 
 	metrics := getMetrics()

--- a/internal/server/identity_service.go
+++ b/internal/server/identity_service.go
@@ -16,13 +16,25 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/sigstore/rekor-tiles/v2/internal/safeint"
 	"github.com/sigstore/rekor-tiles/v2/internal/tessera"
 	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/sigstore/rekor-tiles/v2/pkg/types/identity"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/transparency-dev/formats/proof"
+	ttessera "github.com/transparency-dev/tessera"
 	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -42,11 +54,92 @@ func NewIdentityServer(storage tessera.Storage, readOnly bool, algorithmRegistry
 	}
 }
 
-func (s *IdentityServer) CreateEntry(_ context.Context, _ *pb.IdentityRequestV001) (*httpbody.HttpBody, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateEntry not implemented")
+func (s *IdentityServer) CreateEntry(ctx context.Context, req *pb.IdentityRequestV001) (*httpbody.HttpBody, error) {
+	if s.readOnly {
+		slog.WarnContext(ctx, "rekor is in read-only mode, cannot create new entry")
+		_ = grpc.SetHeader(ctx, metadata.Pairs(httpStatusCodeHeader, "405"))
+		_ = grpc.SetHeader(ctx, metadata.Pairs(httpErrorMessageHeader, "This log has been frozen, please switch to the latest log."))
+		return nil, status.Errorf(codes.Unimplemented, "log frozen")
+	}
+
+	leafBytes, err := identity.ToLogEntry(req)
+	if err != nil {
+		slog.WarnContext(ctx, "failed validating identity request", "error", err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "invalid identity request")
+	}
+
+	entry := ttessera.NewEntry(leafBytes)
+	tle, err := s.storage.Add(ctx, entry)
+	if errors.Is(err, ttessera.ErrPushback) {
+		return nil, status.Errorf(codes.Unavailable, "reached max pushback; retry")
+	}
+	if errors.Is(err, context.Canceled) {
+		return nil, status.Error(codes.Canceled, err.Error())
+	}
+	var dupErr tessera.DuplicateError
+	if errors.As(err, &dupErr) {
+		_ = grpc.SetHeader(ctx, metadata.Pairs(
+			duplicateEntryHeader,
+			strconv.FormatUint(dupErr.Index(), 10)))
+		return nil, status.Error(codes.AlreadyExists, err.Error())
+	}
+	if errors.As(err, &tessera.InclusionProofVerificationError{}) {
+		getMetrics().inclusionProofFailureCount.Inc()
+	}
+	if err != nil {
+		slog.WarnContext(ctx, "failed to integrate entry", "error", err.Error())
+		return nil, status.Errorf(codes.Unknown, "failed to integrate entry")
+	}
+
+	_ = grpc.SetHeader(ctx, metadata.Pairs(httpStatusCodeHeader, "201"))
+	getMetrics().newIdentityEntries.Inc()
+
+	var proofHashes [][32]byte
+	for _, h := range tle.InclusionProof.Hashes {
+		var arr [32]byte
+		copy(arr[:], h)
+		proofHashes = append(proofHashes, arr)
+	}
+
+	var extraData []byte
+	var contextBytes []byte
+	if cred, ok := req.Credential.(*pb.IdentityRequestV001_PublicKey); ok {
+		contextBytes = cred.PublicKey.GetContext()
+	}
+
+	if len(contextBytes) > 0 {
+		extraData = fmt.Appendf(nil, "%s:%s", identity.ContextKeyName, hex.EncodeToString(contextBytes))
+	}
+
+	index, err := safeint.NewSafeInt64(tle.InclusionProof.LogIndex)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "internal error, index out of bounds")
+	}
+	p := proof.TLogProof{
+		Index:      index.U(),
+		Hashes:     proofHashes,
+		Checkpoint: []byte(tle.InclusionProof.Checkpoint.Envelope),
+		ExtraData:  extraData,
+	}
+	proofBytes := p.Marshal()
+
+	return &httpbody.HttpBody{
+		ContentType: "text/plain",
+		Data:        proofBytes,
+	}, nil
 }
 
 // Check implements the Healthcheck protocol to report the health of the service.
 func (s IdentityServer) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+// RegisterGRPC registers the Identity Rekor service with the gRPC server.
+func (s *IdentityServer) RegisterGRPC(gs *grpc.Server) {
+	pb.RegisterIdentityRekorServer(gs, s)
+}
+
+// RegisterHTTP registers the Identity Rekor service HTTP handler from endpoint with the gateway mux.
+func (s *IdentityServer) RegisterHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return pb.RegisterIdentityRekorHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }

--- a/internal/server/identity_service_test.go
+++ b/internal/server/identity_service_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	rekor_pb "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor-tiles/v2/internal/algorithmregistry"
+	"github.com/sigstore/rekor-tiles/v2/internal/tessera"
+	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestCreateIdentityEntry(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, err := cryptoutils.MarshalPublicKeyToDER(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgHash := sha256.Sum256([]byte("hello world"))
+	payload := []byte("c2sp.org/identity-transparency/v1\x00")
+	msgDoubleHash := sha256.Sum256(msgHash[:])
+	payload = append(payload, msgDoubleHash[:]...)
+	sig := ed25519.Sign(priv, payload)
+
+	tests := []struct {
+		name         string
+		req          *pb.IdentityRequestV001
+		addFn        func() (*rekor_pb.TransparencyLogEntry, error)
+		expectError  error
+		expectedCode codes.Code
+	}{
+		{
+			name: "valid request",
+			req: &pb.IdentityRequestV001{
+				Credential: &pb.IdentityRequestV001_PublicKey{
+					PublicKey: &pb.PublicKeyCredential{
+						PublicKey: pubBytes,
+						Signature: sig,
+					},
+				},
+				Message: msgHash[:],
+			},
+			addFn: func() (*rekor_pb.TransparencyLogEntry, error) {
+				return &rekor_pb.TransparencyLogEntry{
+					InclusionProof: &rekor_pb.InclusionProof{
+						LogIndex:   1,
+						Checkpoint: &rekor_pb.Checkpoint{Envelope: "checkpoint"},
+					},
+				}, nil
+			},
+		},
+		{
+			name: "failed validation",
+			req: &pb.IdentityRequestV001{
+				Credential: &pb.IdentityRequestV001_PublicKey{
+					PublicKey: &pb.PublicKeyCredential{
+						PublicKey: pubBytes,
+						Signature: sig,
+					},
+				},
+				Message: make([]byte, 31), // invalid message length
+			},
+			addFn: func() (*rekor_pb.TransparencyLogEntry, error) {
+				return &rekor_pb.TransparencyLogEntry{}, nil
+			},
+			expectError:  fmt.Errorf("invalid identity request"),
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name: "failed integration",
+			req: &pb.IdentityRequestV001{
+				Credential: &pb.IdentityRequestV001_PublicKey{
+					PublicKey: &pb.PublicKeyCredential{
+						PublicKey: pubBytes,
+						Signature: sig,
+					},
+				},
+				Message: msgHash[:],
+			},
+			addFn: func() (*rekor_pb.TransparencyLogEntry, error) {
+				return nil, fmt.Errorf("timed out")
+			},
+			expectError:  fmt.Errorf("failed to integrate entry"),
+			expectedCode: codes.Unknown,
+		},
+		{
+			name: "inclusion proof verification failure",
+			req: &pb.IdentityRequestV001{
+				Credential: &pb.IdentityRequestV001_PublicKey{
+					PublicKey: &pb.PublicKeyCredential{
+						PublicKey: pubBytes,
+						Signature: sig,
+					},
+				},
+				Message: msgHash[:],
+			},
+			addFn: func() (*rekor_pb.TransparencyLogEntry, error) {
+				return nil, tessera.InclusionProofVerificationError{}
+			},
+			expectError:  fmt.Errorf("failed to integrate entry"),
+			expectedCode: codes.Unknown,
+		},
+		{
+			name: "index out of bounds",
+			req: &pb.IdentityRequestV001{
+				Credential: &pb.IdentityRequestV001_PublicKey{
+					PublicKey: &pb.PublicKeyCredential{
+						PublicKey: pubBytes,
+						Signature: sig,
+					},
+				},
+				Message: msgHash[:],
+			},
+			addFn: func() (*rekor_pb.TransparencyLogEntry, error) {
+				return &rekor_pb.TransparencyLogEntry{
+					InclusionProof: &rekor_pb.InclusionProof{
+						LogIndex:   -1,
+						Checkpoint: &rekor_pb.Checkpoint{Envelope: "checkpoint"},
+					},
+				}, nil
+			},
+			expectError:  fmt.Errorf("internal error, index out of bounds"),
+			expectedCode: codes.Internal,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := &mockStorage{addFn: test.addFn}
+			algReg, err := algorithmregistry.AlgorithmRegistry([]string{"ed25519"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := NewIdentityServer(storage, false, algReg)
+
+			gotBody, gotErr := server.CreateEntry(context.Background(), test.req)
+			if test.expectError == nil {
+				assert.NoError(t, gotErr)
+				assert.NotNil(t, gotBody)
+				assert.Equal(t, "text/plain", gotBody.ContentType)
+			} else {
+				s, ok := status.FromError(gotErr)
+				assert.True(t, ok)
+				assert.Equal(t, test.expectedCode, s.Code())
+				assert.ErrorContains(t, gotErr, test.expectError.Error())
+			}
+		})
+	}
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -42,6 +42,7 @@ type metrics struct {
 	serverMetrics *grpc_prometheus.ServerMetrics
 	// metrics
 	newHashedRekordEntries     prometheus.Counter
+	newIdentityEntries         prometheus.Counter
 	httpLatency                *prometheus.HistogramVec
 	httpRequestsCount          *prometheus.CounterVec
 	httpRequestSize            *prometheus.HistogramVec
@@ -68,6 +69,11 @@ var _initMetricsFunc = sync.OnceValue(func() *metrics {
 	m.newHashedRekordEntries = f.NewCounter(prometheus.CounterOpts{
 		Name: "rekor_v2_new_hashedrekord_entries",
 		Help: "The total number of new hashedrekord log entries",
+	})
+
+	m.newIdentityEntries = f.NewCounter(prometheus.CounterOpts{
+		Name: "rekor_v2_new_identity_entries",
+		Help: "The total number of new identity log entries",
 	})
 
 	// grpc_packet_part should always be "payload" but we can measure "header" or "trailer" in the future

--- a/internal/server/serve.go
+++ b/internal/server/serve.go
@@ -21,12 +21,30 @@ import (
 	"sync"
 	"time"
 
-	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
+// GRPCRegistrar allows different log implementations to register their gRPC service and health check.
+type GRPCRegistrar interface {
+	RegisterGRPC(s *grpc.Server)
+	grpc_health_v1.HealthServer
+}
+
+// HTTPRegistrar allows different log implementations to register their HTTP gateway handler.
+type HTTPRegistrar interface {
+	RegisterHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
+}
+
+// Registrar allows different log implementations to register themselves for gRPC and HTTP.
+type Registrar interface {
+	GRPCRegistrar
+	HTTPRegistrar
+}
+
 // Serve starts the grpc server and its http proxy.
-func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, tesseraTimeout time.Duration, s any, tesseraShutdownFn func(context.Context) error) {
+func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, tesseraTimeout time.Duration, s Registrar, tesseraShutdownFn func(context.Context) error) {
 	var wg sync.WaitGroup
 
 	if hc.port == 0 || gc.port == 0 {
@@ -35,18 +53,6 @@ func Serve(ctx context.Context, hc *HTTPConfig, gc *GRPCConfig, tesseraTimeout t
 	}
 	if hc.port == gc.port && hc.host == gc.host {
 		slog.Error("http and grpc cannot serve at the same address", "host", hc.host, "port", hc.port)
-		os.Exit(1)
-	}
-
-	_, isRekor := s.(pb.RekorServer)
-	_, isIdentity := s.(pb.IdentityRekorServer)
-	if !isRekor && !isIdentity {
-		slog.Error("service does not implement RekorServer or IdentityRekorServer")
-		os.Exit(1)
-	}
-
-	if _, ok := s.(grpc_health_v1.HealthServer); !ok {
-		slog.Error("service does not implement gRPC HealthServer")
 		os.Exit(1)
 	}
 

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	"github.com/sigstore/rekor-tiles/v2/internal/tessera"
@@ -154,4 +155,14 @@ func (s *Server) GetCheckpoint(context.Context, *emptypb.Empty) (*httpbody.HttpB
 // See https://grpc-ecosystem.github.io/grpc-gateway/docs/operations/health_check/.
 func (s Server) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+// RegisterGRPC registers the Rekor service with the gRPC server.
+func (s *Server) RegisterGRPC(gs *grpc.Server) {
+	pb.RegisterRekorServer(gs, s)
+}
+
+// RegisterHTTP registers the Rekor service HTTP handler from endpoint with the gateway mux.
+func (s *Server) RegisterHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return pb.RegisterRekorHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }

--- a/internal/server/service_mock.go
+++ b/internal/server/service_mock.go
@@ -35,11 +35,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	pbsc "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	pbs "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
 	"github.com/transparency-dev/tessera/api/layout"
 	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -224,6 +226,14 @@ func (s *mockRekorServer) GetCheckpoint(_ context.Context, _ *emptypb.Empty) (*h
 
 func (s mockRekorServer) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+func (s *mockRekorServer) RegisterGRPC(gs *grpc.Server) {
+	pb.RegisterRekorServer(gs, s)
+}
+
+func (s *mockRekorServer) RegisterHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return pb.RegisterRekorHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
 func generateSelfSignedCert(t testing.TB) (certFile, keyFile string) {

--- a/pkg/generated/protobuf/identity.pb.go
+++ b/pkg/generated/protobuf/identity.pb.go
@@ -43,7 +43,10 @@ type PublicKeyCredential struct {
 	PublicKey []byte `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
 	// The signature computed over the specification identifier, checksum, and context strings,
 	// as defined by the c2sp.org/identity-transparency specification.
-	Signature     []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
+	Signature []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
+	// Optional context value to record alongside the message. Must be a SHA-256 digest.
+	// Must be signed as defined by the c2sp.org/identity-transparency specification.
+	Context       []byte `protobuf:"bytes,3,opt,name=context,proto3" json:"context,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -92,6 +95,13 @@ func (x *PublicKeyCredential) GetSignature() []byte {
 	return nil
 }
 
+func (x *PublicKeyCredential) GetContext() []byte {
+	if x != nil {
+		return x.Context
+	}
+	return nil
+}
+
 // A request to add an identity-based transparency log entry (v0.0.1)
 type IdentityRequestV001 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -100,9 +110,7 @@ type IdentityRequestV001 struct {
 	//	*IdentityRequestV001_PublicKey
 	Credential isIdentityRequestV001_Credential `protobuf_oneof:"credential"`
 	// Must be a SHA-256 digest of data.
-	Message []byte `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	// Optional context value. Must be a SHA-256 digest.
-	Context       []byte `protobuf:"bytes,4,opt,name=context,proto3" json:"context,omitempty"`
+	Message       []byte `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -160,13 +168,6 @@ func (x *IdentityRequestV001) GetMessage() []byte {
 	return nil
 }
 
-func (x *IdentityRequestV001) GetContext() []byte {
-	if x != nil {
-		return x.Context
-	}
-	return nil
-}
-
 type isIdentityRequestV001_Credential interface {
 	isIdentityRequestV001_Credential()
 }
@@ -181,16 +182,16 @@ var File_rekor_v2_identity_proto protoreflect.FileDescriptor
 
 const file_rekor_v2_identity_proto_rawDesc = "" +
 	"\n" +
-	"\x17rekor/v2/identity.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\"\\\n" +
+	"\x17rekor/v2/identity.proto\x12\x15dev.sigstore.rekor.v2\x1a\x1fgoogle/api/field_behavior.proto\"v\n" +
 	"\x13PublicKeyCredential\x12\"\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fB\x03\xe0A\x02R\tpublicKey\x12!\n" +
-	"\tsignature\x18\x02 \x01(\fB\x03\xe0A\x02R\tsignature\"\xa9\x01\n" +
+	"\tsignature\x18\x02 \x01(\fB\x03\xe0A\x02R\tsignature\x12\x18\n" +
+	"\acontext\x18\x03 \x01(\fR\acontext\"\x8f\x01\n" +
 	"\x13IdentityRequestV001\x12K\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\v2*.dev.sigstore.rekor.v2.PublicKeyCredentialH\x00R\tpublicKey\x12\x1d\n" +
-	"\amessage\x18\x03 \x01(\fB\x03\xe0A\x02R\amessage\x12\x18\n" +
-	"\acontext\x18\x04 \x01(\fR\acontextB\f\n" +
+	"\amessage\x18\x03 \x01(\fB\x03\xe0A\x02R\amessageB\f\n" +
 	"\n" +
 	"credentialB\x81\x01\n" +
 	"\x1bdev.sigstore.proto.rekor.v2B\x0fRekorV2IdentityP\x01Z9github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf\xea\x02\x13Sigstore::Rekor::V2b\x06proto3"

--- a/pkg/types/identity/identity.go
+++ b/pkg/types/identity/identity.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/transparency-dev/merkle/rfc6962"
+)
+
+const (
+	SpecDomainSeparatorV1 = "c2sp.org/identity-transparency/v1"
+	LeafVersionV1         = byte(0x01)
+	ContextKeyName        = "context"
+)
+
+func validate(req *pb.IdentityRequestV001) error {
+	if req == nil {
+		return errors.New("request is nil")
+	}
+
+	switch cred := req.Credential.(type) {
+	case *pb.IdentityRequestV001_PublicKey:
+		if len(cred.PublicKey.GetPublicKey()) == 0 {
+			return errors.New("public key is empty")
+		}
+		if len(cred.PublicKey.GetSignature()) != ed25519.SignatureSize {
+			return errors.New("invalid signature length, must be 64 bytes for Ed25519")
+		}
+		if len(cred.PublicKey.GetContext()) > 0 && len(cred.PublicKey.GetContext()) != sha256.Size {
+			return errors.New("invalid context value hash size, must be 32 bytes")
+		}
+	default:
+		return errors.New("unsupported or missing credential type")
+	}
+
+	if len(req.GetMessage()) != sha256.Size {
+		return errors.New("invalid message hash size, must be 32 bytes")
+	}
+
+	return nil
+}
+
+func computeSignaturePayload(req *pb.IdentityRequestV001) []byte {
+	payload := []byte(SpecDomainSeparatorV1)
+	payload = append(payload, 0x00)
+
+	msgHash := sha256.Sum256(req.GetMessage())
+	payload = append(payload, msgHash[:]...)
+
+	var contextBytes []byte
+	if cred, ok := req.Credential.(*pb.IdentityRequestV001_PublicKey); ok {
+		contextBytes = cred.PublicKey.GetContext()
+	}
+
+	if len(contextBytes) > 0 {
+		k1 := sha256.Sum256([]byte(ContextKeyName))
+		kDoubleHash := sha256.Sum256(k1[:])
+		vDoubleHash := sha256.Sum256(contextBytes)
+		payload = append(payload, kDoubleHash[:]...)
+		payload = append(payload, vDoubleHash[:]...)
+	}
+
+	return payload
+}
+
+func computeLeafHash(req *pb.IdentityRequestV001, rootPubKeyHash []byte) []byte {
+	leaf := []byte{LeafVersionV1}
+
+	leaf = append(leaf, rootPubKeyHash...)
+
+	msgHash := sha256.Sum256(req.GetMessage())
+	leaf = append(leaf, msgHash[:]...)
+
+	var sig []byte
+	var contextBytes []byte
+	if cred, ok := req.Credential.(*pb.IdentityRequestV001_PublicKey); ok {
+		sig = cred.PublicKey.GetSignature()
+		contextBytes = cred.PublicKey.GetContext()
+	}
+
+	if len(contextBytes) > 0 {
+		k1 := sha256.Sum256([]byte(ContextKeyName))
+		kDoubleHash := sha256.Sum256(k1[:])
+		vDoubleHash := sha256.Sum256(contextBytes)
+		leaf = append(leaf, kDoubleHash[:]...)
+		leaf = append(leaf, vDoubleHash[:]...)
+	}
+
+	// Note: Rekor does not currently store the signature as a receipt
+	// to prove a valid credential was provided. In a future revision,
+	// Rekor will persist the signature in out-of-tree storage.
+	sigHash := sha256.Sum256(sig)
+	leaf = append(leaf, sigHash[:]...)
+
+	return leaf
+}
+
+// ToLogEntry reconstructs the leaf bytes from bundle-signed inputs.
+// It validates the signature and returns the unhashed leaf format.
+func ToLogEntry(req *pb.IdentityRequestV001) ([]byte, error) {
+	if err := validate(req); err != nil {
+		return nil, err
+	}
+
+	var pubKey, sig []byte
+	switch cred := req.Credential.(type) {
+	case *pb.IdentityRequestV001_PublicKey:
+		pubKey = cred.PublicKey.GetPublicKey()
+		sig = cred.PublicKey.GetSignature()
+	default:
+		return nil, errors.New("unsupported credential type")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+	edKey, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("public key is not an Ed25519 key")
+	}
+
+	payload := computeSignaturePayload(req)
+
+	if !ed25519.Verify(edKey, payload, sig) {
+		return nil, errors.New("invalid signature")
+	}
+
+	rootOfTrust := append([]byte("Ed25519"), pubKey...)
+	rootPubKeyHash := sha256.Sum256(rootOfTrust)
+	return computeLeafHash(req, rootPubKeyHash[:]), nil
+}
+
+// ToEntryHash reconstructs the identity log entry from bundle-signed
+// inputs and returns its entry hash.
+func ToEntryHash(publicKey []byte, signature []byte, message []byte, context []byte) ([]byte, error) {
+	req := &pb.IdentityRequestV001{
+		Credential: &pb.IdentityRequestV001_PublicKey{
+			PublicKey: &pb.PublicKeyCredential{
+				PublicKey: publicKey,
+				Signature: signature,
+				Context:   context,
+			},
+		},
+		Message: message,
+	}
+	leafBytes, err := ToLogEntry(req)
+	if err != nil {
+		return nil, err
+	}
+	return rfc6962.DefaultHasher.HashLeaf(leafBytes), nil
+}

--- a/pkg/types/identity/identity_test.go
+++ b/pkg/types/identity/identity_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+
+	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/transparency-dev/merkle/rfc6962"
+)
+
+func generateValidRequest(t *testing.T) (*pb.IdentityRequestV001, []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+
+	pubBytes, err := cryptoutils.MarshalPublicKeyToDER(pub)
+	assert.NoError(t, err)
+
+	msg := []byte("test message")
+	msgHash := sha256.Sum256(msg)
+
+	v := []byte("val1")
+	vHash := sha256.Sum256(v)
+
+	payload := []byte(SpecDomainSeparatorV1)
+	payload = append(payload, 0x00)
+
+	msgDoubleHash := sha256.Sum256(msgHash[:])
+	payload = append(payload, msgDoubleHash[:]...)
+
+	k1 := sha256.Sum256([]byte(ContextKeyName))
+	kDoubleHash := sha256.Sum256(k1[:])
+	vDoubleHash := sha256.Sum256(vHash[:])
+	payload = append(payload, kDoubleHash[:]...)
+	payload = append(payload, vDoubleHash[:]...)
+
+	sig := ed25519.Sign(priv, payload)
+
+	req := &pb.IdentityRequestV001{
+		Credential: &pb.IdentityRequestV001_PublicKey{
+			PublicKey: &pb.PublicKeyCredential{
+				PublicKey: pubBytes,
+				Signature: sig,
+				Context:   vHash[:],
+			},
+		},
+		Message: msgHash[:],
+	}
+	return req, payload
+}
+
+func TestToLogEntry(t *testing.T) {
+	req, _ := generateValidRequest(t)
+
+	leafBytes, err := ToLogEntry(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, leafBytes)
+	assert.Greater(t, len(leafBytes), 0)
+	assert.Equal(t, byte(0x01), leafBytes[0]) // Leaf hash starts with 0x01
+
+	rootOfTrust := append([]byte("Ed25519"), req.GetPublicKey().GetPublicKey()...)
+	rootPubKeyHash := sha256.Sum256(rootOfTrust)
+	assert.Equal(t, rootPubKeyHash[:], leafBytes[1:33]) // H(RoT) comes first after version byte
+
+	msgHash := sha256.Sum256(req.GetMessage())
+	assert.Equal(t, msgHash[:], leafBytes[33:65]) // H(H(data)) comes second after version byte
+}
+
+func TestToLogEntry_InvalidSignature(t *testing.T) {
+	req, _ := generateValidRequest(t)
+
+	// Invalidate the signature by flipping the first byte
+	req.GetPublicKey().Signature[0] ^= 0xFF
+
+	leafBytes, err := ToLogEntry(req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid signature")
+	assert.Nil(t, leafBytes)
+}
+
+func TestValidate_InvalidMessageSize(t *testing.T) {
+	req, _ := generateValidRequest(t)
+
+	// Invalid message size
+	req.Message = []byte("short")
+
+	err := validate(req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid message hash size")
+}
+
+func TestToEntryHash(t *testing.T) {
+	req, _ := generateValidRequest(t)
+
+	leafBytes, err := ToLogEntry(req)
+	assert.NoError(t, err)
+
+	expectedHash := rfc6962.DefaultHasher.HashLeaf(leafBytes)
+
+	h, err := ToEntryHash(req.GetPublicKey().GetPublicKey(), req.GetPublicKey().GetSignature(), req.Message, req.GetPublicKey().GetContext())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHash, h)
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,3 +81,23 @@ When finished, you can clean up the Docker containers if desired:
 ```sh
 docker compose -f cloudsql-compose.yml down --volumes
 ```
+
+### Identity POSIX Server
+
+Start the Docker containers from the top level directory:
+
+```sh
+docker compose -f identity-posix-compose.yml up -d --build --wait --wait-timeout 60
+```
+
+Run the tests:
+
+```sh
+go test -v -tags=e2e -run TestIdentityPOSIX ./tests/
+```
+
+When finished, you can clean up the Docker containers if desired:
+
+```sh
+docker compose -f identity-posix-compose.yml down --volumes
+```

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -376,7 +376,7 @@ func testPersistentDeduplication(t *testing.T, config backendConfig) {
 
 func artifactDigest(idx uint64) []byte {
 	baseArtifact := "testartifact"
-	artifact := []byte(fmt.Sprintf("%s%d", baseArtifact, idx))
+	artifact := fmt.Appendf(nil, "%s%d", baseArtifact, idx)
 	digest := sha256.Sum256(artifact)
 	return digest[:]
 }

--- a/tests/identity_e2e_test.go
+++ b/tests/identity_e2e_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	pb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/sigstore/rekor-tiles/v2/pkg/client/read"
+	"github.com/sigstore/rekor-tiles/v2/pkg/note"
+	"github.com/sigstore/rekor-tiles/v2/pkg/types/identity"
+	"github.com/sigstore/rekor-tiles/v2/pkg/verify"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/stretchr/testify/assert"
+	f_note "github.com/transparency-dev/formats/note"
+	tlogproof "github.com/transparency-dev/formats/proof"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
+	signednote "golang.org/x/mod/sumdb/note"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var identityPosixConfig = backendConfig{
+	ServerURL:   "http://localhost:3006",
+	StorageURL:  "http://localhost:8001",
+	ComposePath: "identity-posix-compose.yml",
+}
+
+func TestIdentityPOSIX(t *testing.T) {
+	t.Run("ReadWrite", func(t *testing.T) {
+		testIdentityReadWrite(t, identityPosixConfig)
+	})
+}
+
+func testIdentityReadWrite(t *testing.T, config backendConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// get verifier needed for both read and write
+	serverPubKeyPEM, err := os.ReadFile(defaultServerPublicKey)
+	assert.NoError(t, err)
+	serverPubKey, err := cryptoutils.UnmarshalPEMToPublicKey(serverPubKeyPEM)
+	assert.NoError(t, err)
+	verifier, err := signature.LoadDefaultVerifier(serverPubKey)
+	assert.NoError(t, err)
+
+	reader, err := read.NewReader(config.StorageURL, defaultRekorHostname, verifier)
+	assert.NoError(t, err)
+	checkpoint, _, err := reader.ReadCheckpoint(ctx)
+	assert.NoError(t, err)
+	initialTreeSize := checkpoint.Size
+
+	// Generate a valid ed25519 keypair
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+
+	pubBytes, err := cryptoutils.MarshalPublicKeyToDER(pub)
+	assert.NoError(t, err)
+
+	// Create a message hash
+	message := []byte("hello world")
+	msgHash := sha256.Sum256(message)
+
+	contextKey := sha256.Sum256([]byte(identity.ContextKeyName))
+	contextVal := sha256.Sum256([]byte("bar"))
+
+	// Compute signature over "c2sp.org/identity-transparency/v1\x00" || H(msgHash) || H(contextKey) || H(contextVal)
+	payload := []byte("c2sp.org/identity-transparency/v1\x00")
+	msgDoubleHash := sha256.Sum256(msgHash[:])
+	payload = append(payload, msgDoubleHash[:]...)
+
+	keyDoubleHash := sha256.Sum256(contextKey[:])
+	valDoubleHash := sha256.Sum256(contextVal[:])
+	payload = append(payload, keyDoubleHash[:]...)
+	payload = append(payload, valDoubleHash[:]...)
+
+	sig := ed25519.Sign(priv, payload)
+
+	req := &pb.IdentityRequestV001{
+		Credential: &pb.IdentityRequestV001_PublicKey{
+			PublicKey: &pb.PublicKeyCredential{
+				PublicKey: pubBytes,
+				Signature: sig,
+				Context:   contextVal[:],
+			},
+		},
+		Message: msgHash[:],
+	}
+
+	b, err := protojson.Marshal(req)
+	assert.NoError(t, err)
+
+	url := fmt.Sprintf("%s/api/v2/log/entries", config.ServerURL)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(b))
+	assert.NoError(t, err)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode, "Expected 201 Created, got: %s", string(respBody))
+
+	// Ensure the response is a tlog-proof object
+	respStr := string(respBody)
+	t.Logf("Response body: %s", respStr)
+
+	var pr tlogproof.TLogProof
+	err = pr.Unmarshal(respBody)
+	assert.NoError(t, err, "Response body should parse as TLogProof")
+
+	noteVerifier, err := note.NewNoteVerifier(defaultRekorHostname, verifier)
+	assert.NoError(t, err)
+
+	witnessNoteVerifier, err := f_note.NewVerifierForCosignatureV1(defaultWitnessVKey)
+	assert.NoError(t, err)
+
+	noteVerifiers := []signednote.Verifier{noteVerifier, witnessNoteVerifier}
+
+	cp, parsedNote, err := verify.VerifyWitnessedCheckpoint(string(pr.Checkpoint), noteVerifiers[0], noteVerifiers[1:]...)
+	assert.NoError(t, err, "Checkpoint should be valid")
+	assert.Len(t, parsedNote.Sigs, 2, "Expected 2 valid signatures, from the log and witness")
+
+	expectedExtraData := fmt.Sprintf("%s:%s", identity.ContextKeyName, hex.EncodeToString(contextVal[:]))
+	assert.Equal(t, []byte(expectedExtraData), pr.ExtraData, "ExtraData should contain the formatted context strings")
+
+	leafHash, err := identity.ToEntryHash(pubBytes, sig, req.Message, contextVal[:])
+	assert.NoError(t, err)
+
+	var hashes [][]byte
+	for _, h := range pr.Hashes {
+		hCopy := h
+		hashes = append(hashes, hCopy[:])
+	}
+
+	err = proof.VerifyInclusion(rfc6962.DefaultHasher, pr.Index, cp.Size, leafHash, hashes, cp.Hash)
+	assert.NoError(t, err, "Inclusion proof should be valid")
+
+	assert.Equal(t, initialTreeSize, pr.Index, "Index should match the tree size from before uploading")
+}


### PR DESCRIPTION
This change begins the implementation for the Identity-based Transparency Logging Server.

This change supports the new entry type, with only Ed25519 signatures as credentials. This will be proceeded by support for OIDC tokens as credentials, and ML-DSA signatures as credentials.

Partially implements https://github.com/sigstore/rekor-tiles/issues/827, with the remaining PRs to support ML-DSA and an additional GCP backend for PGI deployment.

Coding assisted with Gemini, reviewed entirely by me.