### PR TITLE
Reject pure Ed25519 in hashedrekord instead of panicking

### DIFF
--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -50,6 +50,13 @@ func ToLogEntry(hr *pb.HashedRekordRequestV002, algorithmRegistry *signature.Alg
 	}
 
 	hashAlg := algDetails.GetHashType()
+	// Some signing algorithms (for example pure Ed25519, PKIX_ED25519) have no
+	// associated prehash, so GetHashType returns crypto.Hash(0). A hashedrekord
+	// always carries a message digest, so reject these here instead of calling
+	// Size() on an unset hash, which panics.
+	if hashAlg == crypto.Hash(0) {
+		return nil, fmt.Errorf("unsupported signing algorithm %s for hashedrekord: no associated digest algorithm", hr.Signature.Verifier.KeyDetails)
+	}
 	expectedSize := hashAlg.Size()
 	if len(hr.Digest) != expectedSize {
 		return nil, fmt.Errorf("digest length (%d) does not match expected size (%d) for algorithm %s", len(hr.Digest), expectedSize, hashAlg.String())

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -50,10 +50,9 @@ func ToLogEntry(hr *pb.HashedRekordRequestV002, algorithmRegistry *signature.Alg
 	}
 
 	hashAlg := algDetails.GetHashType()
-	// Some signing algorithms (for example pure Ed25519, PKIX_ED25519) have no
-	// associated prehash, so GetHashType returns crypto.Hash(0). A hashedrekord
-	// always carries a message digest, so reject these here instead of calling
-	// Size() on an unset hash, which panics.
+	// hashedrekord only permits signing algorithms that prehash the data.
+	// Pure Ed25519 (PKIX_ED25519) does not, so GetHashType returns crypto.Hash(0);
+	// reject it here rather than calling Size() on an unset hash.
 	if hashAlg == crypto.Hash(0) {
 		return nil, fmt.Errorf("unsupported signing algorithm %s for hashedrekord: no associated digest algorithm", hr.Signature.Verifier.KeyDetails)
 	}

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
@@ -380,6 +381,39 @@ func TestToLogEntry(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestToLogEntryEd25519NoPrehash covers a pure Ed25519 key (PKIX_ED25519),
+// which is in the default allowed set but has no associated prehash, so
+// GetHashType returns crypto.Hash(0). ToLogEntry must reject it with a clean
+// error rather than panic on crypto.Hash(0).Size().
+func TestToLogEntryEd25519NoPrehash(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &pb.HashedRekordRequestV002{
+		Signature: &pb.Signature{
+			Content: []byte("signature-placeholder"),
+			Verifier: &pb.Verifier{
+				Verifier: &pb.Verifier_PublicKey{
+					PublicKey: &pb.PublicKey{RawBytes: der},
+				},
+				KeyDetails: v1.PublicKeyDetails_PKIX_ED25519,
+			},
+		},
+		Digest: bytes.Repeat([]byte{0xab}, 64),
+	}
+	algReg, err := signature.NewAlgorithmRegistryConfig([]v1.PublicKeyDetails{v1.PublicKeyDetails_PKIX_ED25519})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ToLogEntry(req, algReg)
+	assert.ErrorContains(t, err, "unsupported signing algorithm")
 }
 
 func hexDecodeOrDie(t *testing.T, hash string) []byte {


### PR DESCRIPTION
### Summary

A hashedrekord request signed with a pure Ed25519 key (`PKIX_ED25519`) crashes `ToLogEntry`. Pure Ed25519 has no prehash, so `algDetails.GetHashType()` returns `crypto.Hash(0)`, and the digest-size check then calls `crypto.Hash(0).Size()`, which panics with "crypto: Size of unknown hash function".

`PKIX_ED25519` is in the default `AllowedClientSigningAlgorithms` set, and the algorithm registry permits an Ed25519 key paired with `Hash(0)`, so a client can trigger this over `CreateEntry`. The gRPC recovery interceptor catches it and returns an internal error per request, but every such request logs a full stack trace and increments the panic counter, so it is a client-reachable per-request crash rather than a purely internal edge case.

### Change

Guard the zero hash before calling `Size()` and return a clear error for a signing algorithm that has no associated digest. Behavior for every other algorithm is unchanged.

### Testing

Added `TestToLogEntryEd25519NoPrehash`, which submits a `PKIX_ED25519` hashedrekord and asserts a clean error. It panics before this change and passes after. `go test ./pkg/types/hashedrekord/ ./internal/server/` is green.
