### PR TITLE
Fix inverted description for --read-only flag

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -31,7 +31,7 @@ import (
 // Initialize adds flags that are shared between all Rekor binaries
 func Initialize(serveCmd *cobra.Command) error {
 	// server configs
-	serveCmd.Flags().Bool("read-only", false, "whether the log should accept new entries")
+	serveCmd.Flags().Bool("read-only", false, "run this server in read-only mode; reject new entries and disable automatic checkpoint publication")
 	serveCmd.Flags().Int("http-port", 3000, "HTTP port to bind to")
 	serveCmd.Flags().String("http-address", "127.0.0.1", "HTTP address to bind to")
 	serveCmd.Flags().Int("http-metrics-port", 2112, "HTTP port to bind metrics to")


### PR DESCRIPTION
## Summary

The help text for `--read-only` describes the opposite of what the flag does.

```go
serveCmd.Flags().Bool("read-only", false, "whether the log should accept new entries")
```

Setting `--read-only=true` makes the log **reject** new entries:

* `Server.CreateEntry` returns `codes.Unimplemented` ("log frozen") with a 405 status header — internal/server/service.go
* the Tessera appender is never started, so checkpoints stop being published automatically — this is uniform across the gcp, gcpcloudsql, aws, and posix binaries

Since the flag is surfaced in `--help`, the current wording could lead an operator to freeze a live log while believing they are enabling writes.

## Change

Reword the description to state the behavior directly:

```
run this server in read-only mode; reject new entries and disable automatic checkpoint publication
```

"Disable automatic checkpoint publication" is deliberate rather than "no new checkpoints": `freeze-checkpoint` still re-signs and uploads a final frozen checkpoint after the server is put into read-only mode.

Documentation-only change; no behavior is modified.