### PR TITLE
Add dispatch tests for the AWS and GCP signer-verifiers

### DIFF
--- a/internal/tessera/aws/signerverifier/signerverifier_test.go
+++ b/internal/tessera/aws/signerverifier/signerverifier_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Sigstore Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signerverifier
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/kms"
+
+	// fakekms provides an in-memory KMS provider so that the KMS branch of New
+	// can be exercised without cloud credentials.
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
+)
+
+// awsKMSScheme is the reference scheme registered by the AWS KMS provider. It is
+// written literally rather than imported so that this package's own blank import
+// is what registers it.
+const awsKMSScheme = "awskms://"
+
+// writeTestKey generates an unencrypted ECDSA private key and returns its path.
+func writeTestKey(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "ec-key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), 0600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+	return keyPath
+}
+
+func TestNewWithFile(t *testing.T) {
+	keyPath := writeTestKey(t)
+	sv, err := New(context.Background(), WithFile(keyPath, ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := []byte("rekor")
+	sig, err := sv.SignMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("signing message: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("verifying signature: %v", err)
+	}
+}
+
+func TestNewWithKMS(t *testing.T) {
+	sv, err := New(context.Background(), WithKMS("fakekms://key", crypto.SHA256))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := []byte("rekor")
+	sig, err := sv.SignMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("signing message: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("verifying signature: %v", err)
+	}
+}
+
+// TestAWSKMSProviderRegistered guards against the blank import of the AWS KMS
+// provider being dropped, which would silently disable awskms:// keys.
+func TestAWSKMSProviderRegistered(t *testing.T) {
+	if !slices.Contains(kms.SupportedProviders(), awsKMSScheme) {
+		t.Errorf("expected %s to be a supported KMS provider, got %v", awsKMSScheme, kms.SupportedProviders())
+	}
+}
+
+func TestNewErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		wantErr string
+	}{
+		{
+			name:    "no options",
+			opts:    nil,
+			wantErr: "insufficient signing parameters provided",
+		},
+		{
+			name:    "missing key file",
+			opts:    []Option{WithFile(filepath.Join(t.TempDir(), "missing.pem"), "")},
+			wantErr: "failed to read key file",
+		},
+		{
+			name:    "tink with unsupported KEK scheme",
+			opts:    []Option{WithTink("unsupported://kek", "keyset.json.enc")},
+			wantErr: "unsupported KMS key type",
+		},
+		{
+			name:    "tink without keyset path",
+			opts:    []Option{WithTink("aws-kms://kek", "")},
+			wantErr: "key encryption key URI or keyset path unset",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv, err := New(context.Background(), tt.opts...)
+			if err == nil {
+				t.Fatalf("expected error, got signer-verifier %v", sv)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/internal/tessera/aws/signerverifier/signerverifier_test.go
+++ b/internal/tessera/aws/signerverifier/signerverifier_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Sigstore Authors
+Copyright 2026 The Sigstore Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/tessera/gcp/signerverifier/signerverifier_test.go
+++ b/internal/tessera/gcp/signerverifier/signerverifier_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Sigstore Authors
+Copyright 2026 The Sigstore Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/tessera/gcp/signerverifier/signerverifier_test.go
+++ b/internal/tessera/gcp/signerverifier/signerverifier_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Sigstore Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signerverifier
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/kms"
+
+	// fakekms provides an in-memory KMS provider so that the KMS branch of New
+	// can be exercised without cloud credentials.
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
+)
+
+// gcpKMSScheme is the reference scheme registered by the GCP KMS provider. It is
+// written literally rather than imported so that this package's own blank import
+// is what registers it.
+const gcpKMSScheme = "gcpkms://"
+
+// writeTestKey generates an unencrypted ECDSA private key and returns its path.
+func writeTestKey(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "ec-key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), 0600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+	return keyPath
+}
+
+func TestNewWithFile(t *testing.T) {
+	keyPath := writeTestKey(t)
+	sv, err := New(context.Background(), WithFile(keyPath, ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := []byte("rekor")
+	sig, err := sv.SignMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("signing message: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("verifying signature: %v", err)
+	}
+}
+
+func TestNewWithKMS(t *testing.T) {
+	sv, err := New(context.Background(), WithKMS("fakekms://key", crypto.SHA256, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := []byte("rekor")
+	sig, err := sv.SignMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("signing message: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("verifying signature: %v", err)
+	}
+}
+
+// TestGCPKMSProviderRegistered guards against the blank import of the GCP KMS
+// provider being dropped, which would silently disable gcpkms:// keys.
+func TestGCPKMSProviderRegistered(t *testing.T) {
+	if !slices.Contains(kms.SupportedProviders(), gcpKMSScheme) {
+		t.Errorf("expected %s to be a supported KMS provider, got %v", gcpKMSScheme, kms.SupportedProviders())
+	}
+}
+
+func TestNewErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		wantErr string
+	}{
+		{
+			name:    "no options",
+			opts:    nil,
+			wantErr: "insufficient signing parameters provided",
+		},
+		{
+			name:    "missing key file",
+			opts:    []Option{WithFile(filepath.Join(t.TempDir(), "missing.pem"), "")},
+			wantErr: "failed to read key file",
+		},
+		{
+			name:    "tink with unsupported KEK scheme",
+			opts:    []Option{WithTink("unsupported://kek", "keyset.json.enc")},
+			wantErr: "unsupported KMS key type",
+		},
+		{
+			name:    "tink without keyset path",
+			opts:    []Option{WithTink("gcp-kms://kek", "")},
+			wantErr: "key encryption key URI or keyset path unset",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv, err := New(context.Background(), tt.opts...)
+			if err == nil {
+				t.Fatalf("expected error, got signer-verifier %v", sv)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`internal/tessera/aws/signerverifier` and `internal/tessera/gcp/signerverifier` currently have no test coverage, even though `New()` selects the checkpoint signing key mechanism for every deployment. This adds a test file to each package covering that dispatch. Test-only change.

## Coverage

For each backend:

* **file branch** — returns a usable signer-verifier (sign/verify round trip) and propagates errors for a missing key file
* **KMS branch** — resolves through the provider registry, exercised with the in-memory `fakekms://` provider so no cloud credentials or network access are required (`internal/signerverifier/tink_test.go` already uses this provider)
* **provider registration** — asserts the backend's own scheme (`gcpkms://` / `awskms://`) is registered. This guards the blank import of the production KMS provider: without it, the KMS test above would still pass if that import were dropped. The scheme is written as a literal rather than imported so the assertion depends only on the package's own import. I verified the assertion fails if the blank import is removed.
* **Tink branch** — an unsupported KEK scheme returns `unsupported KMS key type`, and a KEK URI without a keyset path returns `key encryption key URI or keyset path unset`. Both return before any KMS client is constructed, so they stay offline. A successful Tink case is not covered, since it needs a real `gcp-kms://` / `aws-kms://` KEK.

Everything runs offline.

## Notes

* The two packages are near-identical but not copy-pasteable: GCP's `WithKMS` takes `(kms, hash, rpcOpts)` while AWS's takes `(kms, hash)`. If there is interest in deduplicating these backends later, these tests give that refactor a safety net.
* Cases mixing multiple options (e.g. KMS plus file) are intentionally not tested — every caller passes exactly one option via a `switch`, so precedence is an implementation detail rather than intended behavior.
* Verified locally: `go test ./internal/... ./pkg/...`, `go vet`, `golangci-lint run` (v2.12.2, as pinned in `Dockerfile.golangci-lint`), and `addlicense -check`.