### PR TITLE
Remove pure Ed25519 and restrict allowed signature algorithms

### DIFF
--- a/internal/algorithmregistry/algorithmregistry.go
+++ b/internal/algorithmregistry/algorithmregistry.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"reflect"
+	"slices"
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -36,7 +37,6 @@ var (
 		v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
 		v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384,
 		v1.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
-		v1.PublicKeyDetails_PKIX_ED25519,
 		v1.PublicKeyDetails_PKIX_ED25519_PH,
 	}
 )
@@ -73,6 +73,10 @@ func AlgorithmRegistry(algorithmOptions []string) (*signature.AlgorithmRegistryC
 			algorithm, err := signature.ParseSignatureAlgorithmFlag(a)
 			if err != nil {
 				return nil, fmt.Errorf("parsing signature algorithm flag: %w", err)
+			}
+			allowed := slices.Contains(AllowedClientSigningAlgorithms, algorithm)
+			if !allowed {
+				return nil, fmt.Errorf("algorithm %s is not in the allowed set", a)
 			}
 			algorithms = append(algorithms, algorithm)
 		}

--- a/internal/algorithmregistry/algorithmregistry_test.go
+++ b/internal/algorithmregistry/algorithmregistry_test.go
@@ -33,28 +33,59 @@ func TestAlgorithmRegistry(t *testing.T) {
 		name             string
 		algorithmOptions []string
 		wantErr          bool
+		errContains      string
 	}{
 		{
 			name:             "defaults",
 			algorithmOptions: nil,
 		},
 		{
-			name: "valid algorithms",
+			name: "valid algorithms subset",
 			algorithmOptions: []string{
 				"ecdsa-sha2-384-nistp384",
 				"ecdsa-sha2-512-nistp521",
-				"ed25519",
 				"rsa-sign-pkcs1-3072-sha256",
 				"rsa-sign-pkcs1-4096-sha256",
 			},
 		},
 		{
-			name: "invalid algorithms",
+			name: "valid algorithms including ed25519-ph",
+			algorithmOptions: []string{
+				"ed25519-ph",
+			},
+		},
+		{
+			name: "invalid algorithm format",
 			algorithmOptions: []string{
 				"foo",
-				"bar",
 			},
-			wantErr: true,
+			wantErr:     true,
+			errContains: "parsing signature algorithm flag",
+		},
+		{
+			name: "valid format but not in allowed set (pure ed25519)",
+			algorithmOptions: []string{
+				"ed25519",
+			},
+			wantErr:     true,
+			errContains: "is not in the allowed set",
+		},
+		{
+			name: "mixed valid and not allowed",
+			algorithmOptions: []string{
+				"ecdsa-sha2-384-nistp384",
+				"ed25519",
+			},
+			wantErr:     true,
+			errContains: "is not in the allowed set",
+		},
+		{
+			name: "valid format but not in allowed set (rsa-pss)",
+			algorithmOptions: []string{
+				"rsa-sign-pss-2048-sha256",
+			},
+			wantErr:     true,
+			errContains: "is not in the allowed set",
 		},
 	}
 	for _, test := range tests {
@@ -62,6 +93,9 @@ func TestAlgorithmRegistry(t *testing.T) {
 			got, gotErr := AlgorithmRegistry(test.algorithmOptions)
 			if test.wantErr {
 				assert.Error(t, gotErr)
+				if test.errContains != "" {
+					assert.Contains(t, gotErr.Error(), test.errContains)
+				}
 				return
 			}
 			assert.NoError(t, gotErr)


### PR DESCRIPTION
* Removes pure Ed25519 from the default set of allowed client signing algorithms. This was allowed previously because of DSSE but now with only hashedrekord, the pure variant won't work since we don't have the preimage to verify.
* Adds validation in AlgorithmRegistry to prevent the server from specifying algorithms outside the allowed default set, only allowing subsets of the default algorithms. This prevents RSA-PSS and pure Ed25519 from being specified.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
