### PR TITLE
client: add WithTransport option for a custom base RoundTripper

### DIFF
--- a/pkg/client/option.go
+++ b/pkg/client/option.go
@@ -17,6 +17,8 @@ package client
 
 import (
 	"crypto/tls"
+	"errors"
+	"net/http"
 	"time"
 )
 
@@ -25,6 +27,7 @@ type Config struct {
 	UserAgent string
 	Timeout   time.Duration
 	TLSConfig *tls.Config
+	Transport http.RoundTripper
 }
 
 // Option customizes the client Config.
@@ -48,5 +51,34 @@ func WithTimeout(timeout time.Duration) Option {
 func WithTLSConfig(tlsConfig *tls.Config) Option {
 	return func(c *Config) {
 		c.TLSConfig = tlsConfig
+	}
+}
+
+// WithTransport sets the base http.RoundTripper used for requests, for
+// example to add retries or to inject a mock in tests. The client still wraps
+// it to set the User-Agent. It is mutually exclusive with WithTLSConfig.
+func WithTransport(transport http.RoundTripper) Option {
+	return func(c *Config) {
+		c.Transport = transport
+	}
+}
+
+// BaseTransport returns the http.RoundTripper selected by the config: the
+// transport set with WithTransport, otherwise an http.Transport using the TLS
+// config set with WithTLSConfig, otherwise http.DefaultTransport. It returns an
+// error if both a transport and a TLS config were set, since a TLS config
+// cannot be applied to an arbitrary RoundTripper.
+func (c *Config) BaseTransport() (http.RoundTripper, error) {
+	switch {
+	case c.Transport != nil && c.TLSConfig != nil:
+		return nil, errors.New("WithTransport and WithTLSConfig are mutually exclusive")
+	case c.Transport != nil:
+		return c.Transport, nil
+	case c.TLSConfig != nil:
+		return &http.Transport{
+			TLSClientConfig: c.TLSConfig,
+		}, nil
+	default:
+		return http.DefaultTransport, nil
 	}
 }

--- a/pkg/client/read/read.go
+++ b/pkg/client/read/read.go
@@ -62,11 +62,9 @@ func NewReader(readURL, origin string, verifier signature.Verifier, opts ...clie
 	if err != nil {
 		return nil, fmt.Errorf("creating note verifier: %w", err)
 	}
-	transport := http.DefaultTransport
-	if cfg.TLSConfig != nil {
-		transport = &http.Transport{
-			TLSClientConfig: cfg.TLSConfig,
-		}
+	transport, err := cfg.BaseTransport()
+	if err != nil {
+		return nil, err
 	}
 	timeout := cfg.Timeout
 	if timeout == 0 {

--- a/pkg/client/read/read_test.go
+++ b/pkg/client/read/read_test.go
@@ -18,6 +18,7 @@ package read
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
@@ -87,6 +88,17 @@ func TestNewReader(t *testing.T) {
 				origin:  "rekor-local",
 			},
 		},
+		{
+			name: "with transport",
+			opts: []client.Option{
+				client.WithTransport(http.DefaultTransport),
+				client.WithUserAgent("test"),
+			},
+			expected: &readClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:7080", Path: "/"},
+				origin:  "rekor-local",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -96,6 +108,17 @@ func TestNewReader(t *testing.T) {
 			assert.Equal(t, test.expected.origin, got.(*readClient).origin)
 		})
 	}
+}
+
+func TestNewReader_TransportAndTLSConfig(t *testing.T) {
+	verifier, err := getVerifier(ed25519PrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewReader("http://localhost:7080", "rekor-local", verifier,
+		client.WithTransport(http.DefaultTransport),
+		client.WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	assert.ErrorContains(t, err, "WithTransport and WithTLSConfig are mutually exclusive")
 }
 
 func TestReadCheckpoint(t *testing.T) {

--- a/pkg/client/write/write.go
+++ b/pkg/client/write/write.go
@@ -57,11 +57,9 @@ func NewWriter(writeURL string, opts ...client.Option) (Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing url %s: %w", writeURL, err)
 	}
-	transport := http.DefaultTransport
-	if cfg.TLSConfig != nil {
-		transport = &http.Transport{
-			TLSClientConfig: cfg.TLSConfig,
-		}
+	transport, err := cfg.BaseTransport()
+	if err != nil {
+		return nil, err
 	}
 	timeout := cfg.Timeout
 	if timeout == 0 {

--- a/pkg/client/write/write_test.go
+++ b/pkg/client/write/write_test.go
@@ -17,6 +17,7 @@ package write
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -33,8 +34,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// countingTransport records how many requests pass through it.
+type countingTransport struct {
+	calls int
+	inner http.RoundTripper
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls++
+	return c.inner.RoundTrip(req)
+}
+
 func TestNewWriter(t *testing.T) {
 	writeURL := "http://localhost:3003"
+	customTransport := &countingTransport{inner: http.DefaultTransport}
 	tests := []struct {
 		name     string
 		opts     []client.Option
@@ -80,6 +93,27 @@ func TestNewWriter(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with transport",
+			opts: []client.Option{
+				client.WithTransport(customTransport),
+			},
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3003"},
+				client:  &http.Client{Transport: customTransport, Timeout: 30 * time.Second},
+			},
+		},
+		{
+			name: "with transport and user agent",
+			opts: []client.Option{
+				client.WithTransport(customTransport),
+				client.WithUserAgent("test"),
+			},
+			expected: &writeClient{
+				baseURL: &url.URL{Scheme: "http", Host: "localhost:3003"},
+				client:  &http.Client{Transport: client.CreateRoundTripper(customTransport, "test"), Timeout: 30 * time.Second},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -89,6 +123,45 @@ func TestNewWriter(t *testing.T) {
 			assert.Equal(t, test.expected.client, got.(*writeClient).client)
 		})
 	}
+}
+
+func TestNewWriter_TransportAndTLSConfig(t *testing.T) {
+	_, err := NewWriter("http://localhost:3003",
+		client.WithTransport(http.DefaultTransport),
+		client.WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	assert.ErrorContains(t, err, "WithTransport and WithTLSConfig are mutually exclusive")
+}
+
+func TestAdd_WithTransport(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "test-agent", r.Header.Get("User-Agent"))
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte("{}"))
+		}))
+	defer server.Close()
+
+	transport := &countingTransport{inner: http.DefaultTransport}
+	writer, err := NewWriter(server.URL, client.WithTransport(transport), client.WithUserAgent("test-agent"))
+	assert.NoError(t, err)
+
+	entry := &pb.HashedRekordRequestV002{
+		Signature: &pb.Signature{
+			Content: []byte("sig"),
+			Verifier: &pb.Verifier{
+				Verifier: &pb.Verifier_PublicKey{
+					PublicKey: &pb.PublicKey{RawBytes: []byte("key")},
+				},
+				KeyDetails: v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+			},
+		},
+		Digest: []byte("digest"),
+	}
+
+	_, err = writer.Add(ctx, entry)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, transport.calls)
 }
 
 func TestAdd(t *testing.T) {


### PR DESCRIPTION
The read and write clients build their transport internally and only expose `WithTLSConfig`, so a caller cannot add retries, tracing, or a test double without replacing the whole client. sigstore-go wants to send Rekor v2 writes through sigstore/sigstore's shared `httpretry` transport (sigstore/sigstore-go#676 does this for Fulcio and the TSA; Rekor v2 is waiting on this option), the same way go-tuf's fetcher exposes `SetHTTPClient`. This PR adds `client.WithTransport(http.RoundTripper)` for both `NewReader` and `NewWriter`.

Key changes:
- **`WithTransport` option**: supplies the base `http.RoundTripper`; `CreateRoundTripper` still wraps it to set the User-Agent, so behaviour is unchanged when the option is not used.
- **`Config.BaseTransport()`**: replaces the duplicated transport selection in `NewReader` and `NewWriter`; returns an error when both `WithTransport` and `WithTLSConfig` are set, since a TLS config cannot be applied to an arbitrary RoundTripper.
- **Tests**: option plumbing for reader and writer, the mutual-exclusion error, and an end-to-end `Add` through a counting transport that also checks the User-Agent is applied.

Assisted by Claude Fable 5.1